### PR TITLE
scan for tag in struct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
 vendor/
+
+# Editors
+.idea

--- a/scanner.go
+++ b/scanner.go
@@ -200,7 +200,9 @@ func scanStruct(t reflect.Type) (meta *scannedStruct) {
 	meta = new(scannedStruct)
 	for i := 0; i < l; i++ {
 		if t.Field(i).Name != "_" {
-			meta.fields = append(meta.fields, i)
+			if t.Field(i).Tag.Get("binary") != "-" {
+				meta.fields = append(meta.fields, i)
+			}
 		}
 	}
 	return


### PR DESCRIPTION
Adds struct tag `binary:"-"` to ignore struct field.
Opens the door for a switch statement for more tags.

Fixes #2 