### PR TITLE
support codecs from js client

### DIFF
--- a/convert_js.go
+++ b/convert_js.go
@@ -1,8 +1,14 @@
+//go:build js
 // +build js
+
 // Copyright (c) Roman Atachiants and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 package binary
+
+func ToBytes(v string) (b []byte) {
+	return []byte(v)
+}
 
 func binaryToString(buf *[]byte) string {
 	return string(*buf)


### PR DESCRIPTION
Support codecs for js client:

github.com/kelindar/binary@v1.0.15/codecs.go:484:11: undefined: ToBytes
github.com/kelindar/binary@v1.0.15/encoder.go:190:10: undefined: ToBytes
