### PR TITLE
Fix #15

### DIFF
--- a/decoder_test.go
+++ b/decoder_test.go
@@ -4,6 +4,7 @@
 package binary
 
 import (
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,4 +25,35 @@ func TestBinaryDecodeToValueErrors(t *testing.T) {
 	err = Unmarshal(b, &v)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(1), v)
+}
+
+type oneByteReader struct {
+	content []byte
+}
+
+// Read method of io.Reader reads *up to* len(buf) bytes.
+// It is possible to read LESS, and it can happen when reading a file.
+func (r *oneByteReader) Read(buf []byte) (n int, err error) {
+	if len(r.content) == 0 {
+		err = io.EOF
+		return
+	}
+
+	if len(buf) == 0 {
+		return
+	}
+	n = 1
+	buf[0] = r.content[0]
+	r.content = r.content[1:]
+	return
+}
+
+func TestDecodeFromReader(t *testing.T) {
+	data := "data string"
+	encoded, err := Marshal(data)
+	assert.NoError(t, err)
+	decoder := NewDecoder(&oneByteReader{content: encoded})
+	str, err := decoder.ReadString()
+	assert.NoError(t, err)
+	assert.Equal(t, data, str)
 }

--- a/reader.go
+++ b/reader.go
@@ -185,7 +185,7 @@ func (r *streamReader) Slice(n int) (buffer []byte, err error) {
 		buffer = make([]byte, n, n)
 	}
 
-	_, err = r.Read(buffer)
+	_, err = io.ReadFull(r, buffer)
 	return
 }
 


### PR DESCRIPTION
Use `io.ReadFull` to prevent from reading only partial of a string.