### PR TITLE
Add TimeCounters type

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Test
+on: [push, pull_request]
+env:
+  GITHUB_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
+  GO111MODULE: "on"
+jobs:
+  test:
+    name: Test with Coverage
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: ["1.19", "1.20"]
+    steps:
+      - name: Set up Go ${{ matrix.go }}
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          go mod download
+      - name: Run Unit Tests
+        run: |
+          go test -race -covermode atomic -coverprofile=profile.cov ./...
+      - name: Upload Coverage
+        uses: shogo82148/actions-goveralls@v1
+        with:
+          path-to-profile: profile.cov

--- a/sorted/codecs_test.go
+++ b/sorted/codecs_test.go
@@ -65,7 +65,7 @@ cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 BenchmarkTimes/encode-12         	   17698	     76181 ns/op	   30893 B/op	       6 allocs/op
 BenchmarkTimes/decode-12         	   22126	     54699 ns/op	   81977 B/op	       2 allocs/op
 */
-func BenchmarkTimes(b *testing.B) {
+func BenchmarkTimestamps(b *testing.B) {
 	var times Timestamps
 	for i := uint64(0); i < 10000; i++ {
 		times = append(times, uint64(time.Now().Unix())+i)
@@ -88,7 +88,6 @@ func BenchmarkTimes(b *testing.B) {
 			binary.Unmarshal(enc, &out)
 		}
 	})
-
 }
 
 func TestPayload(t *testing.T) {

--- a/sorted/counters.go
+++ b/sorted/counters.go
@@ -1,0 +1,65 @@
+package sorted
+
+import (
+	"reflect"
+	"sort"
+
+	"github.com/kelindar/binary"
+)
+
+// ------------------------------------------------------------------------------
+
+type tczCodec struct{}
+
+// EncodeTo encodes a value into the encoder.
+func (tczCodec) EncodeTo(e *binary.Encoder, rv reflect.Value) (err error) {
+	data := rv.Interface().(TimeCounters)
+	if !sort.IsSorted(&data) {
+		sort.Sort(&data)
+	}
+
+	buffer := make([]byte, 0, 4*len(data.Time))
+	buffer = appendDelta(buffer, data.Time)
+	buffer = appendDelta(buffer, data.Data)
+
+	// Writhe the size and the buffer
+	e.WriteUvarint(uint64(len(data.Time)))
+	e.WriteUvarint(uint64(len(buffer)))
+	e.Write(buffer)
+	return
+}
+
+// DecodeTo decodes into a reflect value from the decoder.
+func (tczCodec) DecodeTo(d *binary.Decoder, rv reflect.Value) error {
+
+	// Read the number of timestamps
+	count, err := d.ReadUvarint()
+	if err != nil {
+		return err
+	}
+
+	// Read the size in bytes
+	size, err := d.ReadUvarint()
+	if err != nil {
+		return err
+	}
+
+	// Read the timestamp buffer
+	buffer, err := d.Slice(int(size))
+	if err != nil {
+		return err
+	}
+
+	// Read the timestamps
+	result := TimeCounters{
+		Time: make([]uint64, count),
+		Data: make([]uint64, count),
+	}
+
+	// Current offset
+	offset := readDelta(result.Time, buffer[0:])
+	offset = readDelta(result.Data, buffer[offset:])
+
+	rv.Set(reflect.ValueOf(result))
+	return nil
+}

--- a/sorted/counters_test.go
+++ b/sorted/counters_test.go
@@ -1,6 +1,3 @@
-// Copyright (c) Roman Atachiants and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for details.
-
 package sorted
 
 import (
@@ -11,10 +8,10 @@ import (
 )
 
 /*
-BenchmarkTimeSeries/encode-10         	   10000	    103506 ns/op	  123136 B/op	       6 allocs/op
-BenchmarkTimeSeries/decode-10         	   13610	     85692 ns/op	  661022 B/op	      22 allocs/op
+BenchmarkTimeCounters/encode-10         	   10000	    105358 ns/op	  123137 B/op	       6 allocs/op
+BenchmarkTimeCounters/decode-10         	   14527	     83441 ns/op	  661026 B/op	      22 allocs/op
 */
-func BenchmarkTimeSeries(b *testing.B) {
+func BenchmarkTimeCounters(b *testing.B) {
 	series := makeTimeCounters(20000)
 	enc, _ := binary.Marshal(&series)
 
@@ -36,25 +33,25 @@ func BenchmarkTimeSeries(b *testing.B) {
 	})
 }
 
-func TestTimeSeries(t *testing.T) {
+func TestTimeCounters(t *testing.T) {
 
 	// Marshal
-	ts := makeTimeSeries(100)
+	ts := makeTimeCounters(100)
 	b, err := binary.Marshal(ts)
 	assert.NoError(t, err)
-	assert.Equal(t, 341, len(b)) // Consider compressing using snappy after
+	assert.Equal(t, 207, len(b)) // Consider compressing using snappy after
 
 	// Unmarshal
-	var out TimeSeries
+	var out TimeCounters
 	assert.NoError(t, binary.Unmarshal(b, &out))
 	assert.Equal(t, 100, len(out.Data))
 	assert.Equal(t, *ts, out)
 }
 
-func makeTimeSeries(count int) *TimeSeries {
-	var ts TimeSeries
+func makeTimeCounters(count int) *TimeCounters {
+	var ts TimeCounters
 	for i := count - 1; i >= 0; i-- {
-		ts.Append(uint64(1500000000+i), float64(i))
+		ts.Append(uint64(1500000000+i), uint64(i))
 	}
 	return &ts
 }

--- a/sorted/types.go
+++ b/sorted/types.go
@@ -141,3 +141,39 @@ func (ts *TimeSeries) Swap(i, j int) {
 func (ts *TimeSeries) GetBinaryCodec() binary.Codec {
 	return tszCodec{}
 }
+
+// ------------------------------------------------------------------------------
+
+// TimeCounters represents a compressed time-series data where the value
+// is itself an unsigned integer. This is particularly useful for counters.
+type TimeCounters struct {
+	Time []uint64 // Sorted timestamps compressed using delta-encoding
+	Data []uint64 // Corresponding uint64 values
+}
+
+// Append appends a new value into the time series.
+func (ts *TimeCounters) Append(time, value uint64) {
+	ts.Time = append(ts.Time, time)
+	ts.Data = append(ts.Data, value)
+}
+
+// Len returns the length of the time-series
+func (ts *TimeCounters) Len() int {
+	return len(ts.Time)
+}
+
+// Less compares two elements of the time series
+func (ts *TimeCounters) Less(i, j int) bool {
+	return ts.Time[i] < ts.Time[j]
+}
+
+// Swap swaps two elements of the time series
+func (ts *TimeCounters) Swap(i, j int) {
+	ts.Time[i], ts.Time[j] = ts.Time[j], ts.Time[i]
+	ts.Data[i], ts.Data[j] = ts.Data[j], ts.Data[i]
+}
+
+// GetBinaryCodec retrieves a custom binary codec.
+func (ts *TimeCounters) GetBinaryCodec() binary.Codec {
+	return tczCodec{}
+}


### PR DESCRIPTION
This PR adds `sorted.TimeCoutners` , which is similar to `sorted.TimeSeries` but with `uint64` values.