### PR TITLE
avoid to using SliceHeader, more portable code

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -1,4 +1,6 @@
+//go:build !js
 // +build !js
+
 // Copyright (c) Roman Atachiants and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
@@ -15,15 +17,11 @@ func ToString(b *[]byte) string {
 }
 
 // ToBytes converts a string to a byte slice without allocating.
-func ToBytes(v string) (b []byte) {
+func ToBytes(v string) []byte {
 	strHeader := (*reflect.StringHeader)(unsafe.Pointer(&v))
-	byteHeader := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	byteHeader.Data = strHeader.Data
+	bytesData := unsafe.Slice((*byte)(unsafe.Pointer(strHeader.Data)), len(v))
 
-	l := len(v)
-	byteHeader.Len = l
-	byteHeader.Cap = l
-	return
+	return bytesData
 }
 
 func binaryToBools(b *[]byte) []bool {


### PR DESCRIPTION
problem description: https://github.com/kelindar/binary/issues/18

`unsafe.SliceHeader` is not portable, we use `unsafe.Slice` instead