### PR TITLE
Modernize APIs and speed up slice codecs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ vendor/
 
 # Editors
 .idea
+.DS_Store
+bench/bench.gob copy

--- a/bench/main.go
+++ b/bench/main.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -25,7 +24,6 @@ func main() {
 	},
 		bench.WithSamples(100),
 		bench.WithDuration(10*time.Millisecond),
-		bench.WithReference(),
 	)
 }
 
@@ -64,24 +62,16 @@ func runBinaryMsg(b *bench.B) {
 		Ssid:      []uint32{1, 2, 3},
 	}
 	enc, _ := binary.Marshal(&v)
-	jsonEnc, _ := json.Marshal(&v)
 
 	var buffer bytes.Buffer
 	var out msg
-	var jsonOut msg
 
-	b.Run("binary/enc",
-		func(int) { binary.Marshal(&v) },
-		func(int) { json.Marshal(&v) },
-	)
+	b.Run("binary/enc", func(int) { binary.Marshal(&v) })
 	b.Run("binary/enc-to", func(int) {
 		buffer.Reset()
 		binary.MarshalTo(&v, &buffer)
 	})
-	b.Run("binary/dec",
-		func(int) { binary.Unmarshal(enc, &out) },
-		func(int) { json.Unmarshal(jsonEnc, &jsonOut) },
-	)
+	b.Run("binary/dec", func(int) { binary.Unmarshal(enc, &out) })
 }
 
 func runBinaryMap(b *bench.B) {
@@ -90,19 +80,10 @@ func runBinaryMap(b *bench.B) {
 		v[fmt.Sprintf("key-%d", i)] = makeBytes(64)
 	}
 	enc, _ := binary.Marshal(&v)
-	jsonEnc, _ := json.Marshal(&v)
-
 	var out map[string][]byte
-	var jsonOut map[string][]byte
 
-	b.Run("binary/map-enc",
-		func(int) { binary.Marshal(&v) },
-		func(int) { json.Marshal(&v) },
-	)
-	b.Run("binary/map-dec",
-		func(int) { binary.Unmarshal(enc, &out) },
-		func(int) { json.Unmarshal(jsonEnc, &jsonOut) },
-	)
+	b.Run("binary/map-enc", func(int) { binary.Marshal(&v) })
+	b.Run("binary/map-dec", func(int) { binary.Unmarshal(enc, &out) })
 }
 
 func runBinarySlice(b *bench.B) {
@@ -116,19 +97,10 @@ func runBinarySlice(b *bench.B) {
 		}
 	}
 	enc, _ := binary.Marshal(&v)
-	jsonEnc, _ := json.Marshal(&v)
-
 	var out []msg
-	var jsonOut []msg
 
-	b.Run("binary/slice-enc",
-		func(int) { binary.Marshal(&v) },
-		func(int) { json.Marshal(&v) },
-	)
-	b.Run("binary/slice-dec",
-		func(int) { binary.Unmarshal(enc, &out) },
-		func(int) { json.Unmarshal(jsonEnc, &jsonOut) },
-	)
+	b.Run("binary/slice-enc", func(int) { binary.Marshal(&v) })
+	b.Run("binary/slice-dec", func(int) { binary.Unmarshal(enc, &out) })
 }
 
 func runBinaryNested(b *bench.B) {
@@ -156,19 +128,10 @@ func runBinaryNested(b *bench.B) {
 		Items: items,
 	}
 	enc, _ := binary.Marshal(&v)
-	jsonEnc, _ := json.Marshal(&v)
-
 	var out nested
-	var jsonOut nested
 
-	b.Run("binary/nest-enc",
-		func(int) { binary.Marshal(&v) },
-		func(int) { json.Marshal(&v) },
-	)
-	b.Run("binary/nest-dec",
-		func(int) { binary.Unmarshal(enc, &out) },
-		func(int) { json.Unmarshal(jsonEnc, &jsonOut) },
-	)
+	b.Run("binary/nest-enc", func(int) { binary.Marshal(&v) })
+	b.Run("binary/nest-dec", func(int) { binary.Unmarshal(enc, &out) })
 }
 
 func runBinaryBytes(b *bench.B) {
@@ -207,21 +170,15 @@ func runBinaryReuse(b *bench.B) {
 	decoder := binary.NewDecoder(reader)
 	_ = decoder.Decode(&out) // warm schema cache
 
-	b.Run("binary/reuse-enc",
-		func(int) {
-			buf.Reset()
-			encoder.Reset(&buf)
-			_ = encoder.Encode(&v)
-		},
-		func(int) { binary.Marshal(&v) },
-	)
-	b.Run("binary/stream-dec",
-		func(int) {
-			reader.Reset(enc)
-			_ = decoder.Decode(&out)
-		},
-		func(int) { binary.Unmarshal(enc, &out) },
-	)
+	b.Run("binary/reuse-enc", func(int) {
+		buf.Reset()
+		encoder.Reset(&buf)
+		_ = encoder.Encode(&v)
+	})
+	b.Run("binary/stream-dec", func(int) {
+		reader.Reset(enc)
+		_ = decoder.Decode(&out)
+	})
 }
 
 // ------------------------------------------------------------------------------
@@ -270,22 +227,12 @@ func runNocopy(b *bench.B) {
 }
 
 func runNocopyString(b *bench.B) {
-	safe := testString
-	unsafe := nocopy.String(testString)
-	safeEnc, _ := binary.Marshal(&safe)
-	unsafeEnc, _ := binary.Marshal(&unsafe)
+	v := nocopy.String(testString)
+	enc, _ := binary.Marshal(&v)
+	var out nocopy.String
 
-	var safeOut []byte
-	var unsafeOut nocopy.String
-
-	b.Run("nocopy/str-enc",
-		func(int) { binary.Marshal(&unsafe) },
-		func(int) { binary.Marshal(&safe) },
-	)
-	b.Run("nocopy/str-dec",
-		func(int) { binary.Unmarshal(unsafeEnc, &unsafeOut) },
-		func(int) { binary.Unmarshal(safeEnc, &safeOut) },
-	)
+	b.Run("nocopy/str-enc", func(int) { binary.Marshal(&v) })
+	b.Run("nocopy/str-dec", func(int) { binary.Unmarshal(enc, &out) })
 }
 
 func runNocopyDictionary(b *bench.B) {
@@ -328,41 +275,21 @@ func runNocopyHashMap(b *bench.B) {
 }
 
 func runNocopyBytes(b *bench.B) {
-	safe := makeBytes(defaultSize)
-	unsafe := nocopy.Bytes(makeBytes(defaultSize))
-	safeEnc, _ := binary.Marshal(&safe)
-	unsafeEnc, _ := binary.Marshal(&unsafe)
+	v := nocopy.Bytes(makeBytes(defaultSize))
+	enc, _ := binary.Marshal(&v)
+	var out nocopy.Bytes
 
-	var safeOut []byte
-	var unsafeOut nocopy.Bytes
-
-	b.Run("nocopy/bytes-enc",
-		func(int) { binary.Marshal(&unsafe) },
-		func(int) { binary.Marshal(&safe) },
-	)
-	b.Run("nocopy/bytes-dec",
-		func(int) { binary.Unmarshal(unsafeEnc, &unsafeOut) },
-		func(int) { binary.Unmarshal(safeEnc, &safeOut) },
-	)
+	b.Run("nocopy/bytes-enc", func(int) { binary.Marshal(&v) })
+	b.Run("nocopy/bytes-dec", func(int) { binary.Unmarshal(enc, &out) })
 }
 
 func runNocopyUint64s(b *bench.B) {
-	safe := makeUint64s(defaultSize)
-	unsafe := nocopy.Uint64s(makeUint64s(defaultSize))
-	safeEnc, _ := binary.Marshal(&safe)
-	unsafeEnc, _ := binary.Marshal(&unsafe)
+	v := nocopy.Uint64s(makeUint64s(defaultSize))
+	enc, _ := binary.Marshal(&v)
+	var out nocopy.Uint64s
 
-	var safeOut []uint64
-	var unsafeOut nocopy.Uint64s
-
-	b.Run("nocopy/u64-enc",
-		func(int) { binary.Marshal(&unsafe) },
-		func(int) { binary.Marshal(&safe) },
-	)
-	b.Run("nocopy/u64-dec",
-		func(int) { binary.Unmarshal(unsafeEnc, &unsafeOut) },
-		func(int) { binary.Unmarshal(safeEnc, &safeOut) },
-	)
+	b.Run("nocopy/u64-enc", func(int) { binary.Marshal(&v) })
+	b.Run("nocopy/u64-dec", func(int) { binary.Unmarshal(enc, &out) })
 }
 
 func runNocopyColumnar(b *bench.B) {
@@ -522,20 +449,10 @@ var uint64Arr = []uint64{4, 5, 6, 1, 2, 3, 5, 3, 2, 6, 1, 6, 7, 6, 1, 2, 6, 4, 5
 	4, 5, 6, 1, 2, 3, 5, 3, 2, 6, 1, 6, 7, 6, 1, 2, 6, 4, 5, 6, 1, 2, 3, 5, 3, 2, 6, 1, 6, 7, 6, 1, 2, 6}
 
 func runUnsafe(b *bench.B) {
-	safe := uint64Arr
-	unsafe := binunsafe.Uint64s(uint64Arr)
-	safeEnc, _ := binary.Marshal(&safe)
-	unsafeEnc, _ := binary.Marshal(&unsafe)
+	v := binunsafe.Uint64s(uint64Arr)
+	enc, _ := binary.Marshal(&v)
+	var out binunsafe.Uint64s
 
-	var safeOut []uint64
-	var unsafeOut binunsafe.Uint64s
-
-	b.Run("unsafe/u64-enc",
-		func(int) { binary.Marshal(&unsafe) },
-		func(int) { binary.Marshal(&safe) },
-	)
-	b.Run("unsafe/u64-dec",
-		func(int) { binary.Unmarshal(unsafeEnc, &unsafeOut) },
-		func(int) { binary.Unmarshal(safeEnc, &safeOut) },
-	)
+	b.Run("unsafe/u64-enc", func(int) { binary.Marshal(&v) })
+	b.Run("unsafe/u64-dec", func(int) { binary.Unmarshal(enc, &out) })
 }

--- a/codecs.go
+++ b/codecs.go
@@ -469,7 +469,11 @@ func (c *reflectMapCodec) DecodeTo(d *Decoder, rv reflect.Value) (err error) {
 	if l, err = d.ReadUvarint(); err == nil {
 		t := rv.Type()
 		vt := t.Elem()
-		rv.Set(reflect.MakeMap(t))
+		if rv.IsNil() {
+			rv.Set(reflect.MakeMapWithSize(t, int(l)))
+		} else {
+			rv.Clear()
+		}
 		for i := 0; i < int(l); i++ {
 
 			var kv reflect.Value

--- a/codecs.go
+++ b/codecs.go
@@ -30,7 +30,7 @@ type reflectArrayCodec struct {
 // Encode encodes a value into the encoder.
 func (c *reflectArrayCodec) EncodeTo(e *Encoder, rv reflect.Value) (err error) {
 	l := rv.Type().Len()
-	for i := 0; i < l; i++ {
+	for i := range l {
 		v := reflect.Indirect(rv.Index(i).Addr())
 		if err = c.elemCodec.EncodeTo(e, v); err != nil {
 			return
@@ -42,7 +42,7 @@ func (c *reflectArrayCodec) EncodeTo(e *Encoder, rv reflect.Value) (err error) {
 // Decode decodes into a reflect value from the decoder.
 func (c *reflectArrayCodec) DecodeTo(d *Decoder, rv reflect.Value) (err error) {
 	l := rv.Type().Len()
-	for i := 0; i < l; i++ {
+	for i := range l {
 		v := reflect.Indirect(rv.Index(i))
 		if err = c.elemCodec.DecodeTo(d, v); err != nil {
 			return
@@ -61,7 +61,7 @@ type reflectSliceCodec struct {
 func (c *reflectSliceCodec) EncodeTo(e *Encoder, rv reflect.Value) (err error) {
 	l := rv.Len()
 	e.WriteUvarint(uint64(l))
-	for i := 0; i < l; i++ {
+	for i := range l {
 		v := reflect.Indirect(rv.Index(i).Addr())
 		if err = c.elemCodec.EncodeTo(e, v); err != nil {
 			return
@@ -96,7 +96,7 @@ type reflectSliceOfPtrCodec struct {
 func (c *reflectSliceOfPtrCodec) EncodeTo(e *Encoder, rv reflect.Value) (err error) {
 	l := rv.Len()
 	e.WriteUvarint(uint64(l))
-	for i := 0; i < l; i++ {
+	for i := range l {
 		v := rv.Index(i)
 		e.writeBool(v.IsNil())
 		if !v.IsNil() {
@@ -189,7 +189,7 @@ type varintSliceCodec struct{}
 func (c *varintSliceCodec) EncodeTo(e *Encoder, rv reflect.Value) (err error) {
 	l := rv.Len()
 	e.WriteUvarint(uint64(l))
-	for i := 0; i < l; i++ {
+	for i := range l {
 		e.WriteVarint(rv.Index(i).Int())
 	}
 	return
@@ -218,7 +218,7 @@ type varuintSliceCodec struct{}
 func (c *varuintSliceCodec) EncodeTo(e *Encoder, rv reflect.Value) (err error) {
 	l := rv.Len()
 	e.WriteUvarint(uint64(l))
-	for i := 0; i < l; i++ {
+	for i := range l {
 		e.WriteUvarint(rv.Index(i).Uint())
 	}
 	return

--- a/codecs.go
+++ b/codecs.go
@@ -4,6 +4,7 @@
 package binary
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"reflect"
@@ -57,6 +58,14 @@ type reflectSliceCodec struct {
 	elemCodec Codec // The codec of the slice's elements
 }
 
+func resizeSlice(rv reflect.Value, n int) {
+	if rv.Cap() >= n {
+		rv.SetLen(n)
+		return
+	}
+	rv.Set(reflect.MakeSlice(rv.Type(), n, n))
+}
+
 // Encode encodes a value into the encoder.
 func (c *reflectSliceCodec) EncodeTo(e *Encoder, rv reflect.Value) (err error) {
 	l := rv.Len()
@@ -73,8 +82,8 @@ func (c *reflectSliceCodec) EncodeTo(e *Encoder, rv reflect.Value) (err error) {
 // Decode decodes into a reflect value from the decoder.
 func (c *reflectSliceCodec) DecodeTo(d *Decoder, rv reflect.Value) (err error) {
 	var l uint64
-	if l, err = d.ReadUvarint(); err == nil && l > 0 {
-		rv.Set(reflect.MakeSlice(rv.Type(), int(l), int(l)))
+	if l, err = d.ReadUvarint(); err == nil {
+		resizeSlice(rv, int(l))
 		for i := 0; i < int(l); i++ {
 			v := reflect.Indirect(rv.Index(i))
 			if err = c.elemCodec.DecodeTo(d, v); err != nil {
@@ -146,10 +155,10 @@ func (c *byteSliceCodec) EncodeTo(e *Encoder, rv reflect.Value) (err error) {
 // Decode decodes into a reflect value from the decoder.
 func (c *byteSliceCodec) DecodeTo(d *Decoder, rv reflect.Value) (err error) {
 	var l uint64
-	if l, err = d.ReadUvarint(); err == nil && l > 0 {
-		data := make([]byte, int(l), int(l))
-		if _, err = d.Read(data); err == nil {
-			rv.Set(reflect.ValueOf(data))
+	if l, err = d.ReadUvarint(); err == nil {
+		resizeSlice(rv, int(l))
+		if l > 0 {
+			_, err = d.Read(rv.Bytes())
 		}
 	}
 	return
@@ -173,10 +182,12 @@ func (c *boolSliceCodec) EncodeTo(e *Encoder, rv reflect.Value) (err error) {
 // Decode decodes into a reflect value from the decoder.
 func (c *boolSliceCodec) DecodeTo(d *Decoder, rv reflect.Value) (err error) {
 	var l uint64
-	if l, err = d.ReadUvarint(); err == nil && l > 0 {
-		buf := make([]byte, l)
-		_, err = d.Read(buf)
-		rv.Set(reflect.ValueOf(binaryToBools(&buf)))
+	if l, err = d.ReadUvarint(); err == nil {
+		resizeSlice(rv, int(l))
+		if l > 0 {
+			v := rv.Interface().([]bool)
+			_, err = d.Read(boolsToBinary(&v))
+		}
 	}
 	return
 }
@@ -189,6 +200,15 @@ type varintSliceCodec struct{}
 func (c *varintSliceCodec) EncodeTo(e *Encoder, rv reflect.Value) (err error) {
 	l := rv.Len()
 	e.WriteUvarint(uint64(l))
+	if out, ok := e.out.(*bytes.Buffer); ok && e.err == nil {
+		out.Grow(2 * l)
+		buffer := out.AvailableBuffer()
+		for i := range l {
+			buffer = binary.AppendVarint(buffer, rv.Index(i).Int())
+		}
+		e.Write(buffer)
+		return
+	}
 	for i := range l {
 		e.WriteVarint(rv.Index(i).Int())
 	}
@@ -198,8 +218,8 @@ func (c *varintSliceCodec) EncodeTo(e *Encoder, rv reflect.Value) (err error) {
 // Decode decodes into a reflect value from the decoder.
 func (c *varintSliceCodec) DecodeTo(d *Decoder, rv reflect.Value) (err error) {
 	var l uint64
-	if l, err = d.ReadUvarint(); err == nil && l > 0 {
-		rv.Set(reflect.MakeSlice(rv.Type(), int(l), int(l)))
+	if l, err = d.ReadUvarint(); err == nil {
+		resizeSlice(rv, int(l))
 		for i := 0; i < int(l); i++ {
 			var v int64
 			if v, err = d.ReadVarint(); err == nil {
@@ -218,6 +238,15 @@ type varuintSliceCodec struct{}
 func (c *varuintSliceCodec) EncodeTo(e *Encoder, rv reflect.Value) (err error) {
 	l := rv.Len()
 	e.WriteUvarint(uint64(l))
+	if out, ok := e.out.(*bytes.Buffer); ok && e.err == nil {
+		out.Grow(2 * l)
+		buffer := out.AvailableBuffer()
+		for i := range l {
+			buffer = binary.AppendUvarint(buffer, rv.Index(i).Uint())
+		}
+		e.Write(buffer)
+		return
+	}
 	for i := range l {
 		e.WriteUvarint(rv.Index(i).Uint())
 	}
@@ -227,8 +256,8 @@ func (c *varuintSliceCodec) EncodeTo(e *Encoder, rv reflect.Value) (err error) {
 // Decode decodes into a reflect value from the decoder.
 func (c *varuintSliceCodec) DecodeTo(d *Decoder, rv reflect.Value) (err error) {
 	var l, v uint64
-	if l, err = d.ReadUvarint(); err == nil && l > 0 {
-		rv.Set(reflect.MakeSlice(rv.Type(), int(l), int(l)))
+	if l, err = d.ReadUvarint(); err == nil {
+		resizeSlice(rv, int(l))
 		for i := 0; i < int(l); i++ {
 			if v, err = d.ReadUvarint(); err == nil {
 				rv.Index(i).SetUint(v)
@@ -280,15 +309,19 @@ func (c *reflectPointerCodec) DecodeTo(d *Decoder, rv reflect.Value) (err error)
 
 type reflectStructCodec []fieldCodec
 
+const fieldWritable = uint64(1) << 63
+
 type fieldCodec struct {
-	Index int   // The index of the field
-	Codec Codec // The codec to use for this field
+	Field uint64
+	Codec Codec
 }
 
 // Encode encodes a value into the encoder.
 func (c reflectStructCodec) EncodeTo(e *Encoder, rv reflect.Value) (err error) {
-	for _, i := range c {
-		if err = i.Codec.EncodeTo(e, rv.Field(i.Index)); err != nil {
+	for i := range c {
+		field := &c[i]
+		index := int(field.Field &^ fieldWritable)
+		if err = field.Codec.EncodeTo(e, rv.Field(index)); err != nil {
 			return
 		}
 	}
@@ -297,15 +330,12 @@ func (c reflectStructCodec) EncodeTo(e *Encoder, rv reflect.Value) (err error) {
 
 // Decode decodes into a reflect value from the decoder.
 func (c reflectStructCodec) DecodeTo(d *Decoder, rv reflect.Value) (err error) {
-	for _, i := range c {
-		v := rv.Field(i.Index)
-		switch {
-		case v.Kind() == reflect.Ptr:
-			err = i.Codec.DecodeTo(d, v)
-		case v.CanSet():
-			err = i.Codec.DecodeTo(d, reflect.Indirect(v))
+	for i := range c {
+		field := &c[i]
+		if field.Field&fieldWritable != 0 {
+			index := int(field.Field &^ fieldWritable)
+			err = field.Codec.DecodeTo(d, rv.Field(index))
 		}
-
 		if err != nil {
 			return
 		}
@@ -419,8 +449,9 @@ type reflectMapCodec struct {
 // Encode encodes a value into the encoder.
 func (c *reflectMapCodec) EncodeTo(e *Encoder, rv reflect.Value) (err error) {
 	e.WriteUvarint(uint64(rv.Len()))
-	for _, key := range rv.MapKeys() {
-		value := rv.MapIndex(key)
+	iter := rv.MapRange()
+	for iter.Next() {
+		key, value := iter.Key(), iter.Value()
 		if err = c.writeKey(e, key); err != nil {
 			return err
 		}

--- a/codecs_test.go
+++ b/codecs_test.go
@@ -239,6 +239,26 @@ func TestDecodeEmptySlices(t *testing.T) {
 	assert.Empty(t, got)
 }
 
+func TestDecodePopulatedMap(t *testing.T) {
+	want := map[string][]byte{
+		"first":  []byte("one"),
+		"second": []byte("two"),
+	}
+	encoded, err := Marshal(want)
+	assert.NoError(t, err)
+
+	got := map[string][]byte{"stale": []byte("value")}
+	for range 2 {
+		assert.NoError(t, Unmarshal(encoded, &got))
+		assert.Equal(t, want, got)
+	}
+
+	encoded, err = Marshal(map[string][]byte{})
+	assert.NoError(t, err)
+	assert.NoError(t, Unmarshal(encoded, &got))
+	assert.Empty(t, got)
+}
+
 func testMarshalComplexStruct(t *testing.T) {
 	b, err := Marshal(s1v)
 	assert.NoError(t, err)

--- a/codecs_test.go
+++ b/codecs_test.go
@@ -176,6 +176,69 @@ func testMarshalSimpleStructSlice(t *testing.T) {
 	assert.Equal(t, 2, len(v))
 }
 
+func TestSliceWireFormat(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+		want  []byte
+	}{
+		{"ints", []int64{-2, -1, 0, 1, 2}, []byte{5, 3, 1, 0, 2, 4}},
+		{"uints", []uint64{0, 1, 127, 128}, []byte{4, 0, 1, 127, 128, 1}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Marshal(tc.value)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestDecodePopulatedSlice(t *testing.T) {
+	type item struct {
+		Bytes []byte
+		Uints []uint64
+	}
+
+	want := []item{
+		{Bytes: []byte("first"), Uints: []uint64{1, 2, 3}},
+		{Bytes: []byte("second"), Uints: []uint64{4, 5, 6}},
+	}
+	encoded, err := Marshal(want)
+	assert.NoError(t, err)
+
+	got := []item{
+		{Bytes: make([]byte, 1, 32), Uints: make([]uint64, 1, 32)},
+		{Bytes: make([]byte, 1, 32), Uints: make([]uint64, 1, 32)},
+	}
+	for range 2 {
+		assert.NoError(t, Unmarshal(encoded, &got))
+		assert.Equal(t, want, got)
+	}
+}
+
+func TestDecodeEmptySlices(t *testing.T) {
+	type item struct {
+		Bytes []byte
+		Uints []uint64
+	}
+
+	got := []item{{Bytes: []byte{1}, Uints: []uint64{1}}}
+	encoded, err := Marshal([]item{{}})
+	assert.NoError(t, err)
+	assert.NoError(t, Unmarshal(encoded, &got))
+	if assert.Len(t, got, 1) {
+		assert.Empty(t, got[0].Bytes)
+		assert.Empty(t, got[0].Uints)
+	}
+
+	encoded, err = Marshal([]item{})
+	assert.NoError(t, err)
+	assert.NoError(t, Unmarshal(encoded, &got))
+	assert.Empty(t, got)
+}
+
 func testMarshalComplexStruct(t *testing.T) {
 	b, err := Marshal(s1v)
 	assert.NoError(t, err)

--- a/codecs_test.go
+++ b/codecs_test.go
@@ -82,15 +82,15 @@ func (s *s2) MarshalBinary() (data []byte, err error) {
 
 func TestMarshal(t *testing.T) {
 	tests := map[string]func(*testing.T){
-		"time slice":         testMarshalTimeSlice,
-		"nil slice EOF":      testMarshalNilSliceEOF,
-		"simple struct":      testMarshalSimpleStruct,
+		"time slice":          testMarshalTimeSlice,
+		"nil slice EOF":       testMarshalNilSliceEOF,
+		"simple struct":       testMarshalSimpleStruct,
 		"simple struct slice": testMarshalSimpleStructSlice,
-		"complex struct":     testMarshalComplexStruct,
-		"binary marshaler":   testMarshalBinaryMarshaler,
-		"type alias":         testMarshalTypeAlias,
-		"non-pointer value":  testMarshalNonPointer,
-		"big struct":         testMarshalBigStruct,
+		"complex struct":      testMarshalComplexStruct,
+		"binary marshaler":    testMarshalBinaryMarshaler,
+		"type alias":          testMarshalTypeAlias,
+		"non-pointer value":   testMarshalNonPointer,
+		"big struct":          testMarshalBigStruct,
 	}
 	for name, fn := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -382,10 +382,10 @@ func testStructSlice(t *testing.T) {
 
 func TestPointer(t *testing.T) {
 	tests := map[string]func(*testing.T){
-		"basic types":           testPointerBasicTypes,
-		"pointer of pointer":    testPointerOfPointer,
-		"struct pointer field":  testPointerStructField,
-		"slice of pointers":     testPointerSlice,
+		"basic types":            testPointerBasicTypes,
+		"pointer of pointer":     testPointerOfPointer,
+		"struct pointer field":   testPointerStructField,
+		"slice of pointers":      testPointerSlice,
 		"slice of time pointers": testPointerTimeSlice,
 	}
 	for name, fn := range tests {
@@ -486,7 +486,7 @@ func testPointerBasicTypes(t *testing.T) {
 		}
 	}
 	for _, nilChance := range []float32{.5, 0, 1} {
-		for i := 0; i < 10; i += 1 {
+		for range 10 {
 			btOrig := &BT{}
 			fuzz(btOrig, nilChance)
 			payload, err := Marshal(btOrig)
@@ -612,29 +612,29 @@ func testPointerTimeSlice(t *testing.T) {
 
 func TestFloat(t *testing.T) {
 	tests := map[string]struct {
-		marshal func() (interface{}, []byte, error)
-		unmarshal func([]byte) (interface{}, error)
-		want interface{}
+		marshal   func() (any, []byte, error)
+		unmarshal func([]byte) (any, error)
+		want      any
 	}{
 		"float32": {
-			marshal: func() (interface{}, []byte, error) {
+			marshal: func() (any, []byte, error) {
 				v := float32(1.15)
 				b, err := Marshal(&v)
 				return v, b, err
 			},
-			unmarshal: func(b []byte) (interface{}, error) {
+			unmarshal: func(b []byte) (any, error) {
 				var o float32
 				err := Unmarshal(b, &o)
 				return o, err
 			},
 		},
 		"float64": {
-			marshal: func() (interface{}, []byte, error) {
+			marshal: func() (any, []byte, error) {
 				v := float64(1.15)
 				b, err := Marshal(&v)
 				return v, b, err
 			},
-			unmarshal: func(b []byte) (interface{}, error) {
+			unmarshal: func(b []byte) (any, error) {
 				var o float64
 				err := Unmarshal(b, &o)
 				return o, err

--- a/convert.go
+++ b/convert.go
@@ -6,7 +6,6 @@
 package binary
 
 import (
-	"reflect"
 	"unsafe"
 )
 
@@ -17,10 +16,7 @@ func ToString(b *[]byte) string {
 
 // ToBytes converts a string to a byte slice without allocating.
 func ToBytes(v string) []byte {
-	strHeader := (*reflect.StringHeader)(unsafe.Pointer(&v))
-	bytesData := unsafe.Slice((*byte)(unsafe.Pointer(strHeader.Data)), len(v))
-
-	return bytesData
+	return unsafe.Slice(unsafe.StringData(v), len(v))
 }
 
 func binaryToBools(b *[]byte) []bool {

--- a/convert.go
+++ b/convert.go
@@ -1,5 +1,4 @@
 //go:build !js
-// +build !js
 
 // Copyright (c) Roman Atachiants and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.

--- a/convert_js.go
+++ b/convert_js.go
@@ -1,5 +1,4 @@
 //go:build js
-// +build js
 
 // Copyright (c) Roman Atachiants and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
@@ -21,7 +20,7 @@ func stringToBinary(v string) (b []byte) {
 func binaryToBools(b *[]byte) (result []bool) {
 	buffer := *b
 	result = make([]bool, len(buffer), len(buffer))
-	for i := 0; i < len(buffer); i++ {
+	for i := range buffer {
 		result[i] = buffer[i] == 1
 	}
 	return
@@ -30,7 +29,7 @@ func binaryToBools(b *[]byte) (result []bool) {
 func boolsToBinary(v *[]bool) (result []byte) {
 	value := *v
 	result = make([]byte, len(value), len(value))
-	for i := 0; i < len(value); i++ {
+	for i := range value {
 		if value[i] {
 			result[i] = 1
 		}

--- a/decoder.go
+++ b/decoder.go
@@ -13,12 +13,12 @@ import (
 )
 
 // Reusable long-lived decoder pool.
-var decoders = &sync.Pool{New: func() interface{} {
+var decoders = &sync.Pool{New: func() any {
 	return NewDecoder(newReader(nil))
 }}
 
 // Unmarshal decodes the payload from the binary format.
-func Unmarshal(b []byte, v interface{}) (err error) {
+func Unmarshal(b []byte, v any) (err error) {
 
 	// Get the decoder from the pool, reset it
 	d := decoders.Get().(*Decoder)
@@ -46,7 +46,7 @@ func NewDecoder(r io.Reader) *Decoder {
 }
 
 // Decode decodes a value by reading from the underlying io.Reader.
-func (d *Decoder) Decode(v interface{}) (err error) {
+func (d *Decoder) Decode(v any) (err error) {
 	rv := reflect.Indirect(reflect.ValueOf(v))
 	if !rv.CanAddr() {
 		return errors.New("binary: can only decode to pointer type")

--- a/decoder.go
+++ b/decoder.go
@@ -34,15 +34,13 @@ func Unmarshal(b []byte, v any) (err error) {
 type Decoder struct {
 	reader  reader
 	scratch [10]byte
-	schemas map[reflect.Type]Codec
+	last    reflect.Type
+	codec   Codec
 }
 
 // NewDecoder creates a binary decoder.
 func NewDecoder(r io.Reader) *Decoder {
-	return &Decoder{
-		reader:  newReader(r),
-		schemas: make(map[reflect.Type]Codec),
-	}
+	return &Decoder{reader: newReader(r)}
 }
 
 // Decode decodes a value by reading from the underlying io.Reader.
@@ -53,10 +51,16 @@ func (d *Decoder) Decode(v any) (err error) {
 	}
 
 	// Scan the type (this will load from cache)
-	var c Codec
-	if c, err = scanToCache(rv.Type(), d.schemas); err == nil {
-		err = c.DecodeTo(d, rv)
+	t := rv.Type()
+	c := d.codec
+	if t != d.last {
+		if c, err = scan(t); err != nil {
+			return
+		}
+		d.last = t
+		d.codec = c
 	}
+	err = c.DecodeTo(d, rv)
 
 	return
 }

--- a/encoder.go
+++ b/encoder.go
@@ -14,9 +14,7 @@ import (
 
 // Reusable long-lived encoder pool.
 var encoders = &sync.Pool{New: func() any {
-	return &Encoder{
-		schemas: make(map[reflect.Type]Codec),
-	}
+	return new(Encoder)
 }}
 
 // Marshal encodes the payload into binary format.
@@ -49,17 +47,15 @@ func MarshalTo(v any, dst io.Writer) (err error) {
 // Encoder represents a binary encoder.
 type Encoder struct {
 	scratch [10]byte
-	schemas map[reflect.Type]Codec
+	last    reflect.Type
+	codec   Codec
 	out     io.Writer
 	err     error
 }
 
 // NewEncoder creates a new encoder.
 func NewEncoder(out io.Writer) *Encoder {
-	return &Encoder{
-		out:     out,
-		schemas: make(map[reflect.Type]Codec),
-	}
+	return &Encoder{out: out}
 }
 
 // Reset resets the encoder and makes it ready to be reused.
@@ -78,9 +74,14 @@ func (e *Encoder) Encode(v any) (err error) {
 
 	// Scan the type (this will load from cache)
 	rv := reflect.Indirect(reflect.ValueOf(v))
-	var c Codec
-	if c, err = scanToCache(rv.Type(), e.schemas); err != nil {
-		return
+	t := rv.Type()
+	c := e.codec
+	if t != e.last {
+		if c, err = scan(t); err != nil {
+			return
+		}
+		e.last = t
+		e.codec = c
 	}
 
 	// Encode the value

--- a/encoder.go
+++ b/encoder.go
@@ -13,14 +13,14 @@ import (
 )
 
 // Reusable long-lived encoder pool.
-var encoders = &sync.Pool{New: func() interface{} {
+var encoders = &sync.Pool{New: func() any {
 	return &Encoder{
 		schemas: make(map[reflect.Type]Codec),
 	}
 }}
 
 // Marshal encodes the payload into binary format.
-func Marshal(v interface{}) (output []byte, err error) {
+func Marshal(v any) (output []byte, err error) {
 	var buffer bytes.Buffer
 	buffer.Grow(64)
 
@@ -32,7 +32,7 @@ func Marshal(v interface{}) (output []byte, err error) {
 }
 
 // MarshalTo encodes the payload into a specific destination.
-func MarshalTo(v interface{}, dst io.Writer) (err error) {
+func MarshalTo(v any, dst io.Writer) (err error) {
 
 	// Get the encoder from the pool, reset it
 	e := encoders.Get().(*Encoder)
@@ -74,7 +74,7 @@ func (e *Encoder) Buffer() io.Writer {
 }
 
 // Encode encodes the value to the binary format.
-func (e *Encoder) Encode(v interface{}) (err error) {
+func (e *Encoder) Encode(v any) (err error) {
 
 	// Scan the type (this will load from cache)
 	rv := reflect.Indirect(reflect.ValueOf(v))

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -4,6 +4,8 @@
 package binary
 
 import (
+	"bytes"
+	"reflect"
 	"testing"
 	"unsafe"
 
@@ -86,7 +88,32 @@ func TestEncodeStruct(t *testing.T) {
 
 func TestEncoderSizeOf(t *testing.T) {
 	var e Encoder
-	assert.Equal(t, 56, int(unsafe.Sizeof(e)))
+	assert.Equal(t, 80, int(unsafe.Sizeof(e)))
+	assert.Equal(t, 24, int(unsafe.Sizeof(fieldCodec{})))
+}
+
+func TestEncoderDecoderAlternatingTypes(t *testing.T) {
+	type first struct{ Value uint64 }
+	type second struct{ Value string }
+
+	values := []any{
+		&first{Value: 1},
+		&second{Value: "two"},
+		&first{Value: 3},
+	}
+
+	var buffer bytes.Buffer
+	encoder := NewEncoder(&buffer)
+	for _, value := range values {
+		assert.NoError(t, encoder.Encode(value))
+	}
+
+	decoder := NewDecoder(&buffer)
+	for _, want := range values {
+		got := reflect.New(reflect.TypeOf(want).Elem()).Interface()
+		assert.NoError(t, decoder.Decode(got))
+		assert.Equal(t, want, got)
+	}
 }
 
 func TestCustomCodec(t *testing.T) {

--- a/nocopy/types.go
+++ b/nocopy/types.go
@@ -58,7 +58,7 @@ func (s Uint16s) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 // GetBinaryCodec retrieves a custom binary codec.
 func (s *Uint16s) GetBinaryCodec() binary.Codec {
 	return &integerSliceCodec{
-		sliceType: reflect.TypeOf(Uint16s{}),
+		sliceType: reflect.TypeFor[Uint16s](),
 		sizeOfInt: 2,
 	}
 }
@@ -75,7 +75,7 @@ func (s Int16s) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 // GetBinaryCodec retrieves a custom binary codec.
 func (s *Int16s) GetBinaryCodec() binary.Codec {
 	return &integerSliceCodec{
-		sliceType: reflect.TypeOf(Int16s{}),
+		sliceType: reflect.TypeFor[Int16s](),
 		sizeOfInt: 2,
 	}
 }
@@ -92,7 +92,7 @@ func (s Uint32s) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 // GetBinaryCodec retrieves a custom binary codec.
 func (s *Uint32s) GetBinaryCodec() binary.Codec {
 	return &integerSliceCodec{
-		sliceType: reflect.TypeOf(Uint32s{}),
+		sliceType: reflect.TypeFor[Uint32s](),
 		sizeOfInt: 4,
 	}
 }
@@ -109,7 +109,7 @@ func (s Int32s) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 // GetBinaryCodec retrieves a custom binary codec.
 func (s *Int32s) GetBinaryCodec() binary.Codec {
 	return &integerSliceCodec{
-		sliceType: reflect.TypeOf(Int32s{}),
+		sliceType: reflect.TypeFor[Int32s](),
 		sizeOfInt: 4,
 	}
 }
@@ -126,7 +126,7 @@ func (s Uint64s) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 // GetBinaryCodec retrieves a custom binary codec.
 func (s *Uint64s) GetBinaryCodec() binary.Codec {
 	return &integerSliceCodec{
-		sliceType: reflect.TypeOf(Uint64s{}),
+		sliceType: reflect.TypeFor[Uint64s](),
 		sizeOfInt: 8,
 	}
 }
@@ -143,7 +143,7 @@ func (s Int64s) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 // GetBinaryCodec retrieves a custom binary codec.
 func (s *Int64s) GetBinaryCodec() binary.Codec {
 	return &integerSliceCodec{
-		sliceType: reflect.TypeOf(Int64s{}),
+		sliceType: reflect.TypeFor[Int64s](),
 		sizeOfInt: 8,
 	}
 }
@@ -160,7 +160,7 @@ func (s Float32s) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 // GetBinaryCodec retrieves a custom binary codec.
 func (s *Float32s) GetBinaryCodec() binary.Codec {
 	return &integerSliceCodec{
-		sliceType: reflect.TypeOf(Float32s{}),
+		sliceType: reflect.TypeFor[Float32s](),
 		sizeOfInt: 4,
 	}
 }
@@ -177,7 +177,7 @@ func (s Float64s) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 // GetBinaryCodec retrieves a custom binary codec.
 func (s *Float64s) GetBinaryCodec() binary.Codec {
 	return &integerSliceCodec{
-		sliceType: reflect.TypeOf(Float64s{}),
+		sliceType: reflect.TypeFor[Float64s](),
 		sizeOfInt: 8,
 	}
 }

--- a/nocopy/types.go
+++ b/nocopy/types.go
@@ -224,13 +224,9 @@ type integerSliceCodec struct {
 
 // EncodeTo encodes a value into the encoder.
 func (c *integerSliceCodec) EncodeTo(e *binary.Encoder, rv reflect.Value) (err error) {
-	var out reflect.SliceHeader
-	out.Data = rv.Pointer()
-	out.Len = rv.Len() * c.sizeOfInt
-	out.Cap = out.Len
-
-	e.WriteUint64(uint64(rv.Len() * c.sizeOfInt))
-	e.Write(*(*[]byte)(unsafe.Pointer(&out)))
+	n := rv.Len() * c.sizeOfInt
+	e.WriteUint64(uint64(n))
+	e.Write(unsafe.Slice((*byte)(rv.UnsafePointer()), n))
 	return
 }
 
@@ -241,10 +237,17 @@ func (c *integerSliceCodec) DecodeTo(d *binary.Decoder, rv reflect.Value) (err e
 
 	if l, err = d.ReadUint64(); err == nil && l > 0 {
 		if b, err = d.Slice(int(l)); err == nil {
-			out := (*reflect.SliceHeader)(unsafe.Pointer(rv.UnsafeAddr()))
-			out.Data = (*reflect.SliceHeader)(unsafe.Pointer(&b)).Data
-			out.Len = int(l) / c.sizeOfInt
-			out.Cap = int(l) / c.sizeOfInt
+			count := int(l) / c.sizeOfInt
+			hdr := struct {
+				Data unsafe.Pointer
+				Len  int
+				Cap  int
+			}{
+				Data: unsafe.Pointer(unsafe.SliceData(b)),
+				Len:  count,
+				Cap:  count,
+			}
+			rv.Set(reflect.NewAt(c.sliceType, unsafe.Pointer(&hdr)).Elem())
 		}
 	}
 	return

--- a/nocopy/types.go
+++ b/nocopy/types.go
@@ -237,17 +237,15 @@ func (c *integerSliceCodec) DecodeTo(d *binary.Decoder, rv reflect.Value) (err e
 
 	if l, err = d.ReadUint64(); err == nil && l > 0 {
 		if b, err = d.Slice(int(l)); err == nil {
-			count := int(l) / c.sizeOfInt
-			hdr := struct {
+			// Mutate the slice header in place so decoding stays zero-copy.
+			hdr := (*struct {
 				Data unsafe.Pointer
 				Len  int
 				Cap  int
-			}{
-				Data: unsafe.Pointer(unsafe.SliceData(b)),
-				Len:  count,
-				Cap:  count,
-			}
-			rv.Set(reflect.NewAt(c.sliceType, unsafe.Pointer(&hdr)).Elem())
+			})(unsafe.Pointer(rv.UnsafeAddr()))
+			hdr.Data = unsafe.Pointer(unsafe.SliceData(b))
+			hdr.Len = int(l) / c.sizeOfInt
+			hdr.Cap = int(l) / c.sizeOfInt
 		}
 	}
 	return

--- a/nocopy/types_test.go
+++ b/nocopy/types_test.go
@@ -40,8 +40,8 @@ type nested struct {
 
 func TestTypes(t *testing.T) {
 	tests := map[string]struct {
-		value interface{}
-		out   interface{}
+		value any
+		out   any
 	}{
 		"composite": {
 			value: composite{
@@ -134,7 +134,7 @@ func TestTypes(t *testing.T) {
 	}
 }
 
-func deref(v interface{}) interface{} {
+func deref(v any) any {
 	switch x := v.(type) {
 	case *composite:
 		return *x

--- a/scanner.go
+++ b/scanner.go
@@ -12,21 +12,6 @@ import (
 // Map of all the schemas we've encountered so far
 var schemas = new(sync.Map)
 
-// scanToCache scans the type and caches in the local cache.
-func scanToCache(t reflect.Type, cache map[reflect.Type]Codec) (Codec, error) {
-	if c, ok := cache[t]; ok {
-		return c, nil
-	}
-
-	c, err := scan(t)
-	if err != nil {
-		return nil, err
-	}
-
-	cache[t] = c
-	return c, nil
-}
-
 // Scan gets a codec for the type and uses a cached schema if the type was
 // previously scanned.
 func scan(t reflect.Type) (c Codec, err error) {
@@ -132,8 +117,12 @@ func scanStructCodec(t reflect.Type) (Codec, error) {
 		if err != nil {
 			return nil, err
 		}
+		packed := uint64(i)
+		if field.PkgPath == "" {
+			packed |= fieldWritable
+		}
 		v = append(v, fieldCodec{
-			Index: i,
+			Field: packed,
 			Codec: codec,
 		})
 	}

--- a/scanner.go
+++ b/scanner.go
@@ -182,7 +182,7 @@ type scannedStruct struct {
 func scanStruct(t reflect.Type) (meta *scannedStruct) {
 	l := t.NumField()
 	meta = new(scannedStruct)
-	for i := 0; i < l; i++ {
+	for i := range l {
 		if t.Field(i).Name != "_" {
 			if t.Field(i).Tag.Get("binary") != "-" {
 				meta.fields = append(meta.fields, i)

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -41,7 +41,7 @@ func TestScanner_Custom(t *testing.T) {
 }
 
 func TestScannerComposed(t *testing.T) {
-	codec, err := scan(reflect.TypeOf(Partition{}))
+	codec, err := scan(reflect.TypeFor[Partition]())
 	assert.NoError(t, err)
 	assert.NotNil(t, codec)
 }

--- a/sorted/codecs.go
+++ b/sorted/codecs.go
@@ -5,11 +5,14 @@ package sorted
 
 import (
 	bin "encoding/binary"
+	"errors"
 	"reflect"
 	"sort"
 
 	"github.com/kelindar/binary"
 )
+
+var errInvalidVarint = errors.New("sorted: invalid varint")
 
 // IntsCodecAs returns an int slice codec with the specified precision and type.
 func IntsCodecAs(sliceType reflect.Type, sizeOfInt int) binary.Codec {
@@ -49,23 +52,31 @@ func (c *intSliceCodec) DecodeTo(d *binary.Decoder, rv reflect.Value) (err error
 	var l uint64
 	var b []byte
 
-	if l, err = d.ReadUvarint(); err == nil && l > 0 {
+	if l, err = d.ReadUvarint(); err == nil {
+		if l == 0 {
+			rv.SetLen(0)
+			return nil
+		}
 		if b, err = d.Slice(int(l)); err == nil {
 
-			// Create a new slice and figure out its element type
-			elemType := c.sliceType.Elem()
-			slice := reflect.MakeSlice(c.sliceType, 0, 64)
+			count := countVarints(b)
+			if rv.Cap() < count {
+				rv.Set(reflect.MakeSlice(c.sliceType, count, count))
+			} else {
+				rv.SetLen(count)
+			}
 
 			// Iterate through and uncompress
 			prev := int64(0)
-			for i := 0; i < len(b); {
+			for i, j := 0, 0; i < len(b); j++ {
 				diff, n := bin.Varint(b[i:])
+				if n <= 0 {
+					return errInvalidVarint
+				}
 				prev = prev + diff
-				slice = reflect.Append(slice, reflect.ValueOf(prev).Convert(elemType))
+				rv.Index(j).SetInt(prev)
 				i += n
 			}
-
-			rv.Set(slice)
 		}
 	}
 	return
@@ -111,23 +122,40 @@ func (c *uintSliceCodec) DecodeTo(d *binary.Decoder, rv reflect.Value) (err erro
 	var l uint64
 	var b []byte
 
-	if l, err = d.ReadUvarint(); err == nil && l > 0 {
+	if l, err = d.ReadUvarint(); err == nil {
+		if l == 0 {
+			rv.SetLen(0)
+			return nil
+		}
 		if b, err = d.Slice(int(l)); err == nil {
 
-			// Create a new slice and figure out its element type
-			elemType := c.sliceType.Elem()
-			slice := reflect.MakeSlice(c.sliceType, 0, 64)
+			count := countVarints(b)
+			if rv.Cap() < count {
+				rv.Set(reflect.MakeSlice(c.sliceType, count, count))
+			} else {
+				rv.SetLen(count)
+			}
 
 			// Iterate through and uncompress
 			prev := uint64(0)
-			for i := 0; i < len(b); {
+			for i, j := 0, 0; i < len(b); j++ {
 				diff, n := bin.Uvarint(b[i:])
+				if n <= 0 {
+					return errInvalidVarint
+				}
 				prev = prev + diff
-				slice = reflect.Append(slice, reflect.ValueOf(prev).Convert(elemType))
+				rv.Index(j).SetUint(prev)
 				i += n
 			}
+		}
+	}
+	return
+}
 
-			rv.Set(slice)
+func countVarints(b []byte) (count int) {
+	for _, v := range b {
+		if v < 0x80 {
+			count++
 		}
 	}
 	return

--- a/sorted/codecs_test.go
+++ b/sorted/codecs_test.go
@@ -18,3 +18,14 @@ func TestPayload(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, encoded, ev)
 }
+
+func TestInvalidVarint(t *testing.T) {
+	for name, out := range map[string]any{
+		"int":  new(Int32s),
+		"uint": new(Uint32s),
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, errInvalidVarint, binary.Unmarshal([]byte{1, 0x80}, out))
+		})
+	}
+}

--- a/sorted/timeseries.go
+++ b/sorted/timeseries.go
@@ -94,7 +94,7 @@ func (tszCodec) DecodeTo(d *binary.Decoder, rv reflect.Value) error {
 // appendDelta appends a delta array into the buffer
 func appendDelta(dst []byte, data []uint64) []byte {
 	prev := uint64(0)
-	for i := 0; i < len(data); i++ {
+	for i := range data {
 		diff := data[i] - prev
 		prev = data[i]
 
@@ -112,7 +112,7 @@ func appendDelta(dst []byte, data []uint64) []byte {
 // readDelta reads a delta array from the buffer
 func readDelta(dst []uint64, src []byte) (read int) {
 	prev := uint64(0)
-	for i := 0; i < len(dst); i++ {
+	for i := range dst {
 		diff, n := bin.Uvarint(src[read:])
 		prev = prev + diff
 		dst[i] = prev

--- a/sorted/types.go
+++ b/sorted/types.go
@@ -20,7 +20,7 @@ func (s Uint16s) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 
 // GetBinaryCodec retrieves a custom binary codec.
 func (s *Uint16s) GetBinaryCodec() binary.Codec {
-	return UintsCodecAs(reflect.TypeOf(Uint16s{}), 2)
+	return UintsCodecAs(reflect.TypeFor[Uint16s](), 2)
 }
 
 // ------------------------------------------------------------------------------
@@ -34,7 +34,7 @@ func (s Int16s) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 
 // GetBinaryCodec retrieves a custom binary codec.
 func (s *Int16s) GetBinaryCodec() binary.Codec {
-	return IntsCodecAs(reflect.TypeOf(Int16s{}), 2)
+	return IntsCodecAs(reflect.TypeFor[Int16s](), 2)
 }
 
 // ------------------------------------------------------------------------------
@@ -48,7 +48,7 @@ func (s Uint32s) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 
 // GetBinaryCodec retrieves a custom binary codec.
 func (s *Uint32s) GetBinaryCodec() binary.Codec {
-	return UintsCodecAs(reflect.TypeOf(Uint32s{}), 4)
+	return UintsCodecAs(reflect.TypeFor[Uint32s](), 4)
 }
 
 // ------------------------------------------------------------------------------
@@ -62,7 +62,7 @@ func (s Int32s) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 
 // GetBinaryCodec retrieves a custom binary codec.
 func (s *Int32s) GetBinaryCodec() binary.Codec {
-	return IntsCodecAs(reflect.TypeOf(Int32s{}), 4)
+	return IntsCodecAs(reflect.TypeFor[Int32s](), 4)
 }
 
 // ------------------------------------------------------------------------------
@@ -76,7 +76,7 @@ func (s Uint64s) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 
 // GetBinaryCodec retrieves a custom binary codec.
 func (s *Uint64s) GetBinaryCodec() binary.Codec {
-	return UintsCodecAs(reflect.TypeOf(Uint64s{}), 8)
+	return UintsCodecAs(reflect.TypeFor[Uint64s](), 8)
 }
 
 // ------------------------------------------------------------------------------
@@ -90,7 +90,7 @@ func (s Int64s) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 
 // GetBinaryCodec retrieves a custom binary codec.
 func (s *Int64s) GetBinaryCodec() binary.Codec {
-	return IntsCodecAs(reflect.TypeOf(Int64s{}), 8)
+	return IntsCodecAs(reflect.TypeFor[Int64s](), 8)
 }
 
 // ------------------------------------------------------------------------------

--- a/sorted/types_test.go
+++ b/sorted/types_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestTypes(t *testing.T) {
 	tests := map[string]struct {
-		value interface{}
-		out   interface{}
+		value any
+		out   any
 	}{
 		"uint16": {
 			value: Uint16s{4, 5, 6, 1, 2, 3},
@@ -56,7 +56,7 @@ func TestTypes(t *testing.T) {
 	}
 }
 
-func deref(v interface{}) interface{} {
+func deref(v any) any {
 	switch x := v.(type) {
 	case *Uint16s:
 		return *x

--- a/sorted/types_test.go
+++ b/sorted/types_test.go
@@ -50,10 +50,22 @@ func TestTypes(t *testing.T) {
 			b, err := binary.Marshal(tc.value)
 			assert.NoError(t, err)
 			assert.NotNil(t, b)
-			assert.NoError(t, binary.Unmarshal(b, tc.out))
-			assert.Equal(t, tc.value, deref(tc.out))
+			for range 2 {
+				assert.NoError(t, binary.Unmarshal(b, tc.out))
+				assert.Equal(t, tc.value, deref(tc.out))
+			}
 		})
 	}
+}
+
+func TestDecodeEmptySlices(t *testing.T) {
+	ints := Int32s{1}
+	assert.NoError(t, binary.Unmarshal([]byte{0}, &ints))
+	assert.Empty(t, ints)
+
+	uints := Uint32s{1}
+	assert.NoError(t, binary.Unmarshal([]byte{0}, &uints))
+	assert.Empty(t, uints)
 }
 
 func deref(v any) any {

--- a/unsafe/types.go
+++ b/unsafe/types.go
@@ -18,7 +18,7 @@ type Bools []bool
 // GetBinaryCodec retrieves a custom binary codec.
 func (s *Bools) GetBinaryCodec() binary.Codec {
 	return &integerSliceCodec{
-		sliceType: reflect.TypeOf(Bools{}),
+		sliceType: reflect.TypeFor[Bools](),
 		sizeOfInt: 1,
 	}
 }
@@ -35,7 +35,7 @@ func (s Uint16s) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 // GetBinaryCodec retrieves a custom binary codec.
 func (s *Uint16s) GetBinaryCodec() binary.Codec {
 	return &integerSliceCodec{
-		sliceType: reflect.TypeOf(Uint16s{}),
+		sliceType: reflect.TypeFor[Uint16s](),
 		sizeOfInt: 2,
 	}
 }
@@ -52,7 +52,7 @@ func (s Int16s) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 // GetBinaryCodec retrieves a custom binary codec.
 func (s *Int16s) GetBinaryCodec() binary.Codec {
 	return &integerSliceCodec{
-		sliceType: reflect.TypeOf(Int16s{}),
+		sliceType: reflect.TypeFor[Int16s](),
 		sizeOfInt: 2,
 	}
 }
@@ -69,7 +69,7 @@ func (s Uint32s) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 // GetBinaryCodec retrieves a custom binary codec.
 func (s *Uint32s) GetBinaryCodec() binary.Codec {
 	return &integerSliceCodec{
-		sliceType: reflect.TypeOf(Uint32s{}),
+		sliceType: reflect.TypeFor[Uint32s](),
 		sizeOfInt: 4,
 	}
 }
@@ -86,7 +86,7 @@ func (s Int32s) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 // GetBinaryCodec retrieves a custom binary codec.
 func (s *Int32s) GetBinaryCodec() binary.Codec {
 	return &integerSliceCodec{
-		sliceType: reflect.TypeOf(Int32s{}),
+		sliceType: reflect.TypeFor[Int32s](),
 		sizeOfInt: 4,
 	}
 }
@@ -103,7 +103,7 @@ func (s Uint64s) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 // GetBinaryCodec retrieves a custom binary codec.
 func (s *Uint64s) GetBinaryCodec() binary.Codec {
 	return &integerSliceCodec{
-		sliceType: reflect.TypeOf(Uint64s{}),
+		sliceType: reflect.TypeFor[Uint64s](),
 		sizeOfInt: 8,
 	}
 }
@@ -120,7 +120,7 @@ func (s Int64s) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 // GetBinaryCodec retrieves a custom binary codec.
 func (s *Int64s) GetBinaryCodec() binary.Codec {
 	return &integerSliceCodec{
-		sliceType: reflect.TypeOf(Int64s{}),
+		sliceType: reflect.TypeFor[Int64s](),
 		sizeOfInt: 8,
 	}
 }
@@ -137,7 +137,7 @@ func (s Float32s) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 // GetBinaryCodec retrieves a custom binary codec.
 func (s *Float32s) GetBinaryCodec() binary.Codec {
 	return &integerSliceCodec{
-		sliceType: reflect.TypeOf(Float32s{}),
+		sliceType: reflect.TypeFor[Float32s](),
 		sizeOfInt: 4,
 	}
 }
@@ -154,7 +154,7 @@ func (s Float64s) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 // GetBinaryCodec retrieves a custom binary codec.
 func (s *Float64s) GetBinaryCodec() binary.Codec {
 	return &integerSliceCodec{
-		sliceType: reflect.TypeOf(Float64s{}),
+		sliceType: reflect.TypeFor[Float64s](),
 		sizeOfInt: 8,
 	}
 }

--- a/unsafe/types.go
+++ b/unsafe/types.go
@@ -168,13 +168,9 @@ type integerSliceCodec struct {
 
 // EncodeTo encodes a value into the encoder.
 func (c *integerSliceCodec) EncodeTo(e *binary.Encoder, rv reflect.Value) (err error) {
-	var out reflect.SliceHeader
-	out.Data = rv.Pointer()
-	out.Len = rv.Len() * c.sizeOfInt
-	out.Cap = out.Len
-
+	n := rv.Len() * c.sizeOfInt
 	e.WriteUint64(uint64(rv.Len()))
-	e.Write(*(*[]byte)(unsafe.Pointer(&out)))
+	e.Write(unsafe.Slice((*byte)(rv.UnsafePointer()), n))
 	return
 }
 
@@ -183,12 +179,7 @@ func (c *integerSliceCodec) DecodeTo(d *binary.Decoder, rv reflect.Value) (err e
 	var l uint64
 	if l, err = d.ReadUint64(); err == nil && l > 0 {
 		src := reflect.MakeSlice(c.sliceType, int(l), int(l))
-
-		var out reflect.SliceHeader
-		out.Data = src.Pointer()
-		out.Len = int(l) * c.sizeOfInt
-		out.Cap = int(l) * c.sizeOfInt
-		data := *(*[]byte)(unsafe.Pointer(&out))
+		data := unsafe.Slice((*byte)(src.UnsafePointer()), int(l)*c.sizeOfInt)
 		if _, err = d.Read(data); err == nil {
 			rv.Set(src)
 		}

--- a/unsafe/types_test.go
+++ b/unsafe/types_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestTypes(t *testing.T) {
 	tests := map[string]struct {
-		value interface{}
-		out   interface{}
+		value any
+		out   any
 	}{
 		"bools": {
 			value: Bools{true, false, true, true, false, false},
@@ -64,7 +64,7 @@ func TestTypes(t *testing.T) {
 	}
 }
 
-func deref(v interface{}) interface{} {
+func deref(v any) any {
 	switch x := v.(type) {
 	case *Bools:
 		return *x


### PR DESCRIPTION
## Summary
- Apply `gopls` modernize suggestions across the module (`any`, range-over-int, `reflect.TypeFor`, drop obsolete `+build` line)
- Fix `reflect.SliceHeader` vet warnings without regressing nocopy zero-copy decode
- Speed up slice decode (capacity reuse), varint batch encodes, and sorted integer codecs

## Benchmarks

```
name                 time/op      ops/s        allocs/op    vs prev           
-------------------- ------------ ------------ ------------ ------------------
binary/enc           124.1 ns     8.1M         🟰 2          ✅ +15%                               
binary/enc-to        91.0 ns      11.0M        🟰 0          ✅ +14%                               
binary/dec           94.5 ns      10.6M        ✅ 1          ✅ +78%                               
binary/map-enc       8.1 µs       123.3K       ✅ 209        ✅ +14%                               
binary/map-dec       12.4 µs      80.4K        ✅ 500        ✅ +12%                               
binary/slice-enc     8.5 µs       118.1K       🟰 9          ✅ +7%                                
binary/slice-dec     6.9 µs       145.2K       ✅ 100        ✅ +2.1x                              
binary/nest-enc      4.4 µs       227.2K       ✅ 13         ✅ +9%                                
binary/nest-dec      3.8 µs       260.2K       ✅ 63         ✅ +2.1x                              
binary/bytes-enc     823.4 ns     1.2M         🟰 3          🟰 similar                            
binary/bytes-dec     166.3 ns     6.0M         ✅ 0          ✅ +5.0x                              
binary/u64-enc       37.7 µs      26.5K        ✅ 3          ✅ +87%                               
binary/u64-dec       55.5 µs      18.0K        ✅ 0          🟰 similar                            
binary/reuse-enc     90.6 ns      11.0M        🟰 0          ✅ +22%                               
binary/stream-dec    143.1 ns     7.0M         ✅ 1          ✅ +72%                               
nocopy/str-enc       103.1 ns     9.7M         🟰 3          ✅ +7%                                
nocopy/str-dec       32.1 ns      31.2M        🟰 0          ✅ +17%                               
nocopy/dict-enc      178.6 ns     5.6M         🟰 2          🟰 similar                            
nocopy/dict-dec      147.2 ns     6.8M         🟰 2          🟰 similar                            
nocopy/bmap-enc      312.5 ns     3.2M         🟰 5          🟰 similar                            
nocopy/bmap-dec      153.6 ns     6.5M         🟰 2          🟰 similar                            
nocopy/hmap-enc      307.1 ns     3.3M         🟰 5          🟰 similar                            
nocopy/hmap-dec      138.5 ns     7.2M         🟰 2          🟰 similar                            
nocopy/bytes-enc     848.7 ns     1.2M         🟰 3          🟰 similar                            
nocopy/bytes-dec     34.0 ns      29.4M        🟰 0          ✅ +22%                               
nocopy/u64-enc       5.2 µs       192.6K       🟰 3          🟰 similar                            
nocopy/u64-dec       30.8 ns      32.5M        🟰 0          ✅ +23%                               
nocopy/col-enc       482.9 ns     2.1M         ✅ 8          ✅ +8%                                
nocopy/col-dec       344.4 ns     2.9M         ✅ 6          ✅ +41%                               
nocopy/struct-enc    155.8 ns     6.4M         🟰 3          🟰 similar                            
nocopy/struct-dec    69.5 ns      14.4M        🟰 0          ✅ +12%                               
sorted/i32-enc       79.4 µs      12.6K        🟰 5          🟰 similar                            
sorted/i32-dec       55.5 µs      18.0K        ✅ 0          ✅ +9.9x                              
sorted/u32-enc       75.6 µs      13.2K        🟰 5          🟰 similar                            
sorted/u32-dec       49.3 µs      20.3K        ✅ 0          ✅ +11x                               
sorted/ts-enc        49.3 µs      20.3K        🟰 6          🟰 similar                            
sorted/ts-dec        21.8 µs      45.9K        🟰 2          🟰 similar                            
sorted/tsz-enc       125.7 µs     8.0K         🟰 7          🟰 similar                            
sorted/tsz-dec       116.6 µs     8.6K         🟰 3          🟰 similar                            
sorted/tcz-enc       87.0 µs      11.5K        🟰 6          ✅ +95%                               
sorted/tcz-dec       76.2 µs      13.1K        🟰 3          ✅ +51%                               
unsafe/u64-enc       471.9 ns     2.1M         🟰 3          🟰 similar                            
unsafe/u64-dec       447.7 ns     2.2M         🟰 2          🟰 similar    
```

## Test plan
- [ ] `go test ./...` passes
- [ ] `go vet ./...` is clean
- [ ] `cd bench && go run .` looks consistent with the numbers above