### PR TITLE
Speed up struct encode/decode with typed field paths

### DIFF
--- a/bench/main.go
+++ b/bench/main.go
@@ -52,6 +52,7 @@ func runBinary(b *bench.B) {
 	runBinaryBytes(b)
 	runBinaryUint64s(b)
 	runBinaryReuse(b)
+	runBinaryTrace(b)
 }
 
 func runBinaryMsg(b *bench.B) {
@@ -179,6 +180,42 @@ func runBinaryReuse(b *bench.B) {
 		reader.Reset(enc)
 		_ = decoder.Decode(&out)
 	})
+}
+
+type tracePayload struct {
+	Spans []traceSpan
+}
+
+type traceSpan struct {
+	Ordinal    uint32
+	At         int64
+	Scope      string
+	Node       string
+	NodeType   string
+	Phase      string
+	Invocation uint32
+	Target     string
+}
+
+func runBinaryTrace(b *bench.B) {
+	value := tracePayload{Spans: make([]traceSpan, 128)}
+	for i := range value.Spans {
+		value.Spans[i] = traceSpan{
+			Ordinal:    uint32(i),
+			At:         int64(i * 1000),
+			Scope:      "workflow",
+			Node:       "node",
+			NodeType:   "activity",
+			Phase:      "completed",
+			Invocation: uint32(i % 4),
+			Target:     "worker",
+		}
+	}
+	enc, _ := binary.Marshal(&value)
+	var out tracePayload
+
+	b.Run("binary/trace-enc", func(int) { binary.Marshal(&value) })
+	b.Run("binary/trace-dec", func(int) { binary.Unmarshal(enc, &out) })
 }
 
 // ------------------------------------------------------------------------------

--- a/codecs.go
+++ b/codecs.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"reflect"
+	"unsafe"
 )
 
 // Constants
@@ -309,19 +310,85 @@ func (c *reflectPointerCodec) DecodeTo(d *Decoder, rv reflect.Value) (err error)
 
 type reflectStructCodec []fieldCodec
 
-const fieldWritable = uint64(1) << 63
+const (
+	fieldOffsetMask = uint64(1)<<56 - 1
+	fieldKindShift  = 56
+	fieldKindMask   = uint64(0x3f) << fieldKindShift
+	fieldIncluded   = uint64(1) << 62
+	fieldWritable   = uint64(1) << 63
+)
 
 type fieldCodec struct {
 	Field uint64
 	Codec Codec
 }
 
+func (f *fieldCodec) offset() uintptr {
+	return uintptr(f.Field & fieldOffsetMask)
+}
+
+func (f *fieldCodec) kind() reflect.Kind {
+	return reflect.Kind((f.Field & fieldKindMask) >> fieldKindShift)
+}
+
 // Encode encodes a value into the encoder.
 func (c reflectStructCodec) EncodeTo(e *Encoder, rv reflect.Value) (err error) {
+	if rv.CanAddr() {
+		base := unsafe.Pointer(rv.UnsafeAddr())
+		for i := range c {
+			field := &c[i]
+			if field.Field&fieldIncluded == 0 {
+				continue
+			}
+			pointer := unsafe.Add(base, field.offset())
+			switch field.kind() {
+			case reflect.String:
+				e.WriteString(*(*string)(pointer))
+			case reflect.Bool:
+				e.writeBool(*(*bool)(pointer))
+			case reflect.Int:
+				e.WriteVarint(int64(*(*int)(pointer)))
+			case reflect.Int8:
+				e.WriteVarint(int64(*(*int8)(pointer)))
+			case reflect.Int16:
+				e.WriteVarint(int64(*(*int16)(pointer)))
+			case reflect.Int32:
+				e.WriteVarint(int64(*(*int32)(pointer)))
+			case reflect.Int64:
+				e.WriteVarint(*(*int64)(pointer))
+			case reflect.Uint:
+				e.WriteUvarint(uint64(*(*uint)(pointer)))
+			case reflect.Uint8:
+				e.WriteUvarint(uint64(*(*uint8)(pointer)))
+			case reflect.Uint16:
+				e.WriteUvarint(uint64(*(*uint16)(pointer)))
+			case reflect.Uint32:
+				e.WriteUvarint(uint64(*(*uint32)(pointer)))
+			case reflect.Uint64:
+				e.WriteUvarint(*(*uint64)(pointer))
+			case reflect.Complex64:
+				e.writeComplex64(*(*complex64)(pointer))
+			case reflect.Complex128:
+				e.writeComplex128(*(*complex128)(pointer))
+			case reflect.Float32:
+				e.WriteFloat32(*(*float32)(pointer))
+			case reflect.Float64:
+				e.WriteFloat64(*(*float64)(pointer))
+			default:
+				if err = field.Codec.EncodeTo(e, rv.Field(i)); err != nil {
+					return
+				}
+			}
+		}
+		return
+	}
+
 	for i := range c {
 		field := &c[i]
-		index := int(field.Field &^ fieldWritable)
-		if err = field.Codec.EncodeTo(e, rv.Field(index)); err != nil {
+		if field.Field&fieldIncluded == 0 {
+			continue
+		}
+		if err = field.Codec.EncodeTo(e, rv.Field(i)); err != nil {
 			return
 		}
 	}
@@ -330,11 +397,140 @@ func (c reflectStructCodec) EncodeTo(e *Encoder, rv reflect.Value) (err error) {
 
 // Decode decodes into a reflect value from the decoder.
 func (c reflectStructCodec) DecodeTo(d *Decoder, rv reflect.Value) (err error) {
+	if rv.CanAddr() {
+		base := unsafe.Pointer(rv.UnsafeAddr())
+		for i := range c {
+			field := &c[i]
+			if field.Field&(fieldIncluded|fieldWritable) != fieldIncluded|fieldWritable {
+				continue
+			}
+			pointer := unsafe.Add(base, field.offset())
+			switch field.kind() {
+			case reflect.String:
+				var value string
+				value, err = d.ReadString()
+				if err != nil {
+					return
+				}
+				*(*string)(pointer) = value
+			case reflect.Bool:
+				var value bool
+				value, err = d.ReadBool()
+				if err != nil {
+					return
+				}
+				*(*bool)(pointer) = value
+			case reflect.Int:
+				var value int64
+				value, err = d.ReadVarint()
+				if err != nil {
+					return
+				}
+				*(*int)(pointer) = int(value)
+			case reflect.Int8:
+				var value int64
+				value, err = d.ReadVarint()
+				if err != nil {
+					return
+				}
+				*(*int8)(pointer) = int8(value)
+			case reflect.Int16:
+				var value int64
+				value, err = d.ReadVarint()
+				if err != nil {
+					return
+				}
+				*(*int16)(pointer) = int16(value)
+			case reflect.Int32:
+				var value int64
+				value, err = d.ReadVarint()
+				if err != nil {
+					return
+				}
+				*(*int32)(pointer) = int32(value)
+			case reflect.Int64:
+				var value int64
+				value, err = d.ReadVarint()
+				if err != nil {
+					return
+				}
+				*(*int64)(pointer) = value
+			case reflect.Uint:
+				var value uint64
+				value, err = d.ReadUvarint()
+				if err != nil {
+					return
+				}
+				*(*uint)(pointer) = uint(value)
+			case reflect.Uint8:
+				var value uint64
+				value, err = d.ReadUvarint()
+				if err != nil {
+					return
+				}
+				*(*uint8)(pointer) = uint8(value)
+			case reflect.Uint16:
+				var value uint64
+				value, err = d.ReadUvarint()
+				if err != nil {
+					return
+				}
+				*(*uint16)(pointer) = uint16(value)
+			case reflect.Uint32:
+				var value uint64
+				value, err = d.ReadUvarint()
+				if err != nil {
+					return
+				}
+				*(*uint32)(pointer) = uint32(value)
+			case reflect.Uint64:
+				var value uint64
+				value, err = d.ReadUvarint()
+				if err != nil {
+					return
+				}
+				*(*uint64)(pointer) = value
+			case reflect.Complex64:
+				var value complex64
+				value, err = d.readComplex64()
+				if err != nil {
+					return
+				}
+				*(*complex64)(pointer) = value
+			case reflect.Complex128:
+				var value complex128
+				value, err = d.readComplex128()
+				if err != nil {
+					return
+				}
+				*(*complex128)(pointer) = value
+			case reflect.Float32:
+				var value float32
+				value, err = d.ReadFloat32()
+				if err != nil {
+					return
+				}
+				*(*float32)(pointer) = value
+			case reflect.Float64:
+				var value float64
+				value, err = d.ReadFloat64()
+				if err != nil {
+					return
+				}
+				*(*float64)(pointer) = value
+			default:
+				if err = field.Codec.DecodeTo(d, rv.Field(i)); err != nil {
+					return
+				}
+			}
+		}
+		return
+	}
+
 	for i := range c {
 		field := &c[i]
-		if field.Field&fieldWritable != 0 {
-			index := int(field.Field &^ fieldWritable)
-			err = field.Codec.DecodeTo(d, rv.Field(index))
+		if field.Field&(fieldIncluded|fieldWritable) == fieldIncluded|fieldWritable {
+			err = field.Codec.DecodeTo(d, rv.Field(i))
 		}
 		if err != nil {
 			return

--- a/codecs.go
+++ b/codecs.go
@@ -313,7 +313,8 @@ type reflectStructCodec []fieldCodec
 const (
 	fieldOffsetMask = uint64(1)<<56 - 1
 	fieldKindShift  = 56
-	fieldKindMask   = uint64(0x3f) << fieldKindShift
+	fieldKindMask   = uint64(0x1f) << fieldKindShift
+	fieldDirect     = uint64(1) << 61
 	fieldIncluded   = uint64(1) << 62
 	fieldWritable   = uint64(1) << 63
 )
@@ -333,7 +334,7 @@ func (f *fieldCodec) kind() reflect.Kind {
 
 // Encode encodes a value into the encoder.
 func (c reflectStructCodec) EncodeTo(e *Encoder, rv reflect.Value) (err error) {
-	if rv.CanAddr() {
+	if rv.CanAddr() && len(c) > 0 && c[0].Field&fieldDirect != 0 {
 		base := unsafe.Pointer(rv.UnsafeAddr())
 		for i := range c {
 			field := &c[i]
@@ -397,11 +398,11 @@ func (c reflectStructCodec) EncodeTo(e *Encoder, rv reflect.Value) (err error) {
 
 // Decode decodes into a reflect value from the decoder.
 func (c reflectStructCodec) DecodeTo(d *Decoder, rv reflect.Value) (err error) {
-	if rv.CanAddr() {
+	if rv.CanAddr() && len(c) > 0 && c[0].Field&fieldDirect != 0 {
 		base := unsafe.Pointer(rv.UnsafeAddr())
 		for i := range c {
 			field := &c[i]
-			if field.Field&(fieldIncluded|fieldWritable) != fieldIncluded|fieldWritable {
+			if field.Field&fieldWritable == 0 {
 				continue
 			}
 			pointer := unsafe.Add(base, field.offset())
@@ -529,7 +530,7 @@ func (c reflectStructCodec) DecodeTo(d *Decoder, rv reflect.Value) (err error) {
 
 	for i := range c {
 		field := &c[i]
-		if field.Field&(fieldIncluded|fieldWritable) == fieldIncluded|fieldWritable {
+		if field.Field&fieldWritable != 0 {
 			err = field.Codec.DecodeTo(d, rv.Field(i))
 		}
 		if err != nil {

--- a/codecs_test.go
+++ b/codecs_test.go
@@ -315,10 +315,13 @@ func testMarshalBigStruct(t *testing.T) {
 
 func TestStruct(t *testing.T) {
 	tests := map[string]func(*testing.T){
-		"nested fields":   testStructNestedFields,
-		"embedded struct": testStructEmbedded,
-		"array of struct": testStructArray,
-		"slice of struct": testStructSlice,
+		"nested fields":         testStructNestedFields,
+		"embedded struct":       testStructEmbedded,
+		"array of struct":       testStructArray,
+		"slice of struct":       testStructSlice,
+		"trace slice wire":      testStructTraceSliceWire,
+		"decode error keeps field": testStructDecodeErrorKeepsField,
+		"custom field codec":    testStructCustomFieldCodec,
 	}
 	for name, fn := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -461,6 +464,84 @@ func testStructSlice(t *testing.T) {
 	if !reflect.DeepEqual(s, v) {
 		t.Fatalf("got= %#v\nwant=%#v\n", v, s)
 	}
+}
+
+type tracePayload struct {
+	Spans []traceSpan
+}
+
+type traceSpan struct {
+	Ordinal    uint32
+	At         int64
+	Scope      string
+	Node       string
+	NodeType   string
+	Phase      string
+	Invocation uint32
+	Target     string
+}
+
+type customFieldString string
+
+func (customFieldString) MarshalBinary() ([]byte, error) {
+	return []byte("custom"), nil
+}
+
+func (s *customFieldString) UnmarshalBinary([]byte) error {
+	*s = "decoded"
+	return nil
+}
+
+func testStructTraceSliceWire(t *testing.T) {
+	want := tracePayload{Spans: []traceSpan{{
+		Ordinal:    1,
+		At:         2,
+		Scope:      "s",
+		Node:       "n",
+		NodeType:   "t",
+		Phase:      "p",
+		Invocation: 3,
+		Target:     "x",
+	}}}
+	wire := []byte{1, 1, 4, 1, 's', 1, 'n', 1, 't', 1, 'p', 3, 1, 'x'}
+
+	encoded, err := Marshal(&want)
+	assert.NoError(t, err)
+	assert.Equal(t, wire, encoded)
+
+	encodedValue, err := Marshal(want)
+	assert.NoError(t, err)
+	assert.Equal(t, wire, encodedValue)
+
+	var got tracePayload
+	assert.NoError(t, Unmarshal(wire, &got))
+	assert.Equal(t, want, got)
+}
+
+func testStructDecodeErrorKeepsField(t *testing.T) {
+	type payload struct {
+		Prefix uint32
+		Value  string
+	}
+
+	got := payload{Value: "keep"}
+	err := Unmarshal([]byte{1, 2, 'x'}, &got)
+	assert.Error(t, err)
+	assert.Equal(t, payload{Prefix: 1, Value: "keep"}, got)
+}
+
+func testStructCustomFieldCodec(t *testing.T) {
+	type payload struct {
+		Value customFieldString
+	}
+
+	wire, err := Marshal(&payload{Value: "input"})
+	assert.NoError(t, err)
+	assert.Equal(t, []byte{6, 'c', 'u', 's', 't', 'o', 'm'}, wire)
+
+	var got payload
+	assert.NoError(t, Unmarshal(wire, &got))
+	assert.Equal(t, payload{Value: "decoded"}, got)
 }
 
 func TestPointer(t *testing.T) {

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -36,7 +36,20 @@ type columnFloat32 struct {
 	Floats []float32
 }
 
-func Test_Full(t *testing.T) {
+func TestEncoder(t *testing.T) {
+	tests := map[string]func(*testing.T){
+		"composite":         testEncoderComposite,
+		"struct bytes":      testEncoderStructBytes,
+		"sizeof":            testEncoderSizeOf,
+		"alternating types": testEncoderAlternatingTypes,
+		"custom codec":      testEncoderCustomCodec,
+	}
+	for name, fn := range tests {
+		t.Run(name, fn)
+	}
+}
+
+func testEncoderComposite(t *testing.T) {
 	v := composite{}
 	v["a"] = column{
 		Varchar: columnVarchar{
@@ -62,37 +75,19 @@ func Test_Full(t *testing.T) {
 	assert.Equal(t, v, o)
 }
 
-func newComposite() composite {
-	v := composite{}
-	v["a"] = column{
-		Varchar: columnVarchar{
-			Nulls: []bool{false, false, false, true, false, false, false, false, true, false, false, false, false, true, false},
-			Sizes: []uint32{2, 2, 2, 0, 2, 2, 2, 2, 0, 2, 2, 2, 2, 0, 2, 2, 2, 2, 0, 2, 2, 2, 2, 0, 2, 2, 2, 2, 0, 2},
-			Bytes: []byte{10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10},
-		},
-	}
-	v["b"] = column{
-		Float64: columnFloat64{
-			Nulls:  []bool{false, false, false, true, false},
-			Floats: []float64{1.1, 2.2, 3.3, 0, 4.4},
-		},
-	}
-	return v
-}
-
-func TestEncodeStruct(t *testing.T) {
+func testEncoderStructBytes(t *testing.T) {
 	b, err := Marshal(s0v)
 	assert.NoError(t, err)
 	assert.Equal(t, s0b, b)
 }
 
-func TestEncoderSizeOf(t *testing.T) {
+func testEncoderSizeOf(t *testing.T) {
 	var e Encoder
 	assert.Equal(t, 80, int(unsafe.Sizeof(e)))
 	assert.Equal(t, 24, int(unsafe.Sizeof(fieldCodec{})))
 }
 
-func TestEncoderDecoderAlternatingTypes(t *testing.T) {
+func testEncoderAlternatingTypes(t *testing.T) {
 	type first struct{ Value uint64 }
 	type second struct{ Value string }
 
@@ -116,7 +111,7 @@ func TestEncoderDecoderAlternatingTypes(t *testing.T) {
 	}
 }
 
-func TestCustomCodec(t *testing.T) {
+func testEncoderCustomCodec(t *testing.T) {
 	v := testCustom("custom codec")
 
 	b, err := Marshal(v)

--- a/scanner.go
+++ b/scanner.go
@@ -110,6 +110,7 @@ func scanSlice(t reflect.Type) (Codec, error) {
 
 func scanStructCodec(t reflect.Type) (Codec, error) {
 	v := make(reflectStructCodec, t.NumField())
+	hasDirect := false
 	for i := range t.NumField() {
 		field := t.Field(i)
 		if field.Name == "_" || field.Tag.Get("binary") == "-" {
@@ -124,6 +125,7 @@ func scanStructCodec(t reflect.Type) (Codec, error) {
 		case *stringCodec, *boolCodec, *varintCodec, *varuintCodec,
 			*complex64Codec, *complex128Codec, *float32Codec, *float64Codec:
 			kind = field.Type.Kind()
+			hasDirect = true
 		}
 		packed := uint64(field.Offset) |
 			uint64(kind)<<fieldKindShift |
@@ -135,6 +137,9 @@ func scanStructCodec(t reflect.Type) (Codec, error) {
 			Field: packed,
 			Codec: codec,
 		}
+	}
+	if hasDirect {
+		v[0].Field |= fieldDirect
 	}
 	return &v, nil
 }

--- a/scanner.go
+++ b/scanner.go
@@ -109,22 +109,32 @@ func scanSlice(t reflect.Type) (Codec, error) {
 }
 
 func scanStructCodec(t reflect.Type) (Codec, error) {
-	s := scanStruct(t)
-	v := make(reflectStructCodec, 0, len(s.fields))
-	for _, i := range s.fields {
+	v := make(reflectStructCodec, t.NumField())
+	for i := range t.NumField() {
 		field := t.Field(i)
+		if field.Name == "_" || field.Tag.Get("binary") == "-" {
+			continue
+		}
 		codec, err := scanType(field.Type)
 		if err != nil {
 			return nil, err
 		}
-		packed := uint64(i)
+		kind := reflect.Invalid
+		switch codec.(type) {
+		case *stringCodec, *boolCodec, *varintCodec, *varuintCodec,
+			*complex64Codec, *complex128Codec, *float32Codec, *float64Codec:
+			kind = field.Type.Kind()
+		}
+		packed := uint64(field.Offset) |
+			uint64(kind)<<fieldKindShift |
+			fieldIncluded
 		if field.PkgPath == "" {
 			packed |= fieldWritable
 		}
-		v = append(v, fieldCodec{
+		v[i] = fieldCodec{
 			Field: packed,
 			Codec: codec,
-		})
+		}
 	}
 	return &v, nil
 }
@@ -162,23 +172,6 @@ func scanPrimitive(kind reflect.Kind) Codec {
 	default:
 		return nil
 	}
-}
-
-type scannedStruct struct {
-	fields []int
-}
-
-func scanStruct(t reflect.Type) (meta *scannedStruct) {
-	l := t.NumField()
-	meta = new(scannedStruct)
-	for i := range l {
-		if t.Field(i).Name != "_" {
-			if t.Field(i).Tag.Get("binary") != "-" {
-				meta.fields = append(meta.fields, i)
-			}
-		}
-	}
-	return
 }
 
 // scanBinaryMarshaler scans whether a type has a custom binary marshaling implemented.


### PR DESCRIPTION
## Summary
- Fast-path addressable struct encode/decode for primitive fields using packed offset/kind metadata
- Keep non-primitive fields on the existing Codec path
- Clean up encoder tests (table-driven `TestEncoder`) and fold struct-slice cases into `TestStruct`
- Add `binary/trace-enc` / `binary/trace-dec` benches for nested struct slices

## Benchmarks

Compared `struct-codec` against **v1.1.0** (`vs v1.1.0` = delta vs tagged release):

```
name                 time/op      ops/s        allocs/op    vs v1.1.0
-------------------- ------------ ------------ ------------ ------------------
binary/enc           114.8 ns     8.7M         🟰 2          ✅ +7%
binary/enc-to        85.7 ns      11.7M        🟰 0          🟰 similar
binary/dec           83.4 ns      12.0M        🟰 1          ✅ +10%
binary/map-enc       8.0 µs       124.6K       🟰 209        🟰 similar
binary/map-dec       12.3 µs      81.2K        🟰 500        🟰 similar
binary/slice-enc     7.6 µs       131.9K       🟰 9          ✅ +8%
binary/slice-dec     6.2 µs       162.5K       🟰 100        ✅ +8%
binary/nest-enc      3.9 µs       253.3K       🟰 13         ✅ +8%
binary/nest-dec      3.5 µs       289.3K       🟰 63         ✅ +8%
binary/bytes-enc     848.8 ns     1.2M         🟰 3          🟰 similar
binary/bytes-dec     166.3 ns     6.0M         🟰 0          🟰 similar
binary/u64-enc       36.6 µs      27.3K        🟰 3          🟰 similar
binary/u64-dec       53.7 µs      18.6K        🟰 0          🟰 similar
binary/reuse-enc     89.4 ns      11.2M        🟰 0          🟰 similar
binary/stream-dec    130.6 ns     7.7M         🟰 1          ✅ +5%
binary/trace-enc     11.8 µs      85.0K        9            new
binary/trace-dec     12.2 µs      82.3K        640          new
nocopy/str-enc       100.8 ns     9.9M         🟰 3          🟰 similar
nocopy/str-dec       31.4 ns      31.9M        🟰 0          🟰 similar
nocopy/dict-enc      172.1 ns     5.8M         🟰 2          🟰 similar
nocopy/dict-dec      142.6 ns     7.0M         🟰 2          🟰 similar
nocopy/bmap-enc      307.1 ns     3.3M         🟰 5          🟰 similar
nocopy/bmap-dec      149.5 ns     6.7M         🟰 2          🟰 similar
nocopy/hmap-enc      300.3 ns     3.3M         🟰 5          🟰 similar
nocopy/hmap-dec      134.6 ns     7.4M         🟰 2          🟰 similar
nocopy/bytes-enc     848.7 ns     1.2M         🟰 3          🟰 similar
nocopy/bytes-dec     32.9 ns      30.4M        🟰 0          🟰 similar
nocopy/u64-enc       5.3 µs       189.4K       🟰 3          🟰 similar
nocopy/u64-dec       29.8 ns      33.5M        🟰 0          🟰 similar
nocopy/col-enc       466.5 ns     2.1M         🟰 8          🟰 similar
nocopy/col-dec       329.9 ns     3.0M         🟰 6          🟰 similar
nocopy/struct-enc    149.8 ns     6.7M         🟰 3          🟰 similar
nocopy/struct-dec    66.7 ns      15.0M        🟰 0          🟰 similar
sorted/i32-enc       76.7 µs      13.0K        🟰 5          🟰 similar
sorted/i32-dec       53.8 µs      18.6K        🟰 0          🟰 similar
sorted/u32-enc       73.1 µs      13.7K        🟰 5          🟰 similar
sorted/u32-dec       47.7 µs      20.9K        🟰 0          🟰 similar
sorted/ts-enc        47.7 µs      21.0K        🟰 6          🟰 similar
sorted/ts-dec        21.3 µs      46.9K        🟰 2          🟰 similar
sorted/tsz-enc       122.2 µs     8.2K         🟰 7          🟰 similar
sorted/tsz-dec       114.0 µs     8.8K         🟰 3          🟰 similar
sorted/tcz-enc       79.8 µs      12.5K        🟰 6          ✅ +8%
sorted/tcz-dec       73.3 µs      13.6K        🟰 3          🟰 similar
unsafe/u64-enc       479.0 ns     2.1M         🟰 3          🟰 similar
unsafe/u64-dec       452.3 ns     2.2M         🟰 2          🟰 similar
```

## Test plan
- [ ] `go test ./...` passes
- [ ] `go vet ./...` is clean
- [ ] `cd bench && go run . -bench binary/trace` runs cleanly