### PR TITLE
Fix nocopy values decoded from streams

### DIFF
--- a/nocopy/types_test.go
+++ b/nocopy/types_test.go
@@ -4,11 +4,27 @@
 package nocopy
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/kelindar/binary"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestStreamDecodeRetainsStrings(t *testing.T) {
+	type pair struct {
+		First  String
+		Second String
+	}
+
+	want := pair{First: "first", Second: "second"}
+	data, err := binary.Marshal(want)
+	assert.NoError(t, err)
+
+	var got pair
+	assert.NoError(t, binary.NewDecoder(bytes.NewReader(data)).Decode(&got))
+	assert.Equal(t, want, got)
+}
 
 type composite map[string]column
 

--- a/reader.go
+++ b/reader.go
@@ -156,7 +156,6 @@ func (r *sliceReader) Reset(b []byte) {
 // streamReader represents a reader implementation for a generic reader (i.e. streams)
 type streamReader struct {
 	Reader
-	scratch [10]byte
 }
 
 // Reader represents the interface a reader should implement.
@@ -179,12 +178,7 @@ func newStreamReader(r io.Reader) *streamReader {
 
 // Slice selects a sub-slice of next bytes.
 func (r *streamReader) Slice(n int) (buffer []byte, err error) {
-	if n <= 10 {
-		buffer = r.scratch[:n]
-	} else {
-		buffer = make([]byte, n, n)
-	}
-
+	buffer = make([]byte, n)
 	_, err = io.ReadFull(r, buffer)
 	return
 }


### PR DESCRIPTION
## Summary

- allocate stable slices when decoding from generic streams
- add a regression test for adjacent short `nocopy.String` fields

## Root cause

`streamReader.Slice` reused one 10-byte scratch buffer. `nocopy.String` and other retained nocopy codecs alias the returned slice, so decoding the next short value overwrote earlier values. Generic streams have no reusable backing buffer, so each retained slice must own its bytes. Slice-backed `Unmarshal` remains zero-copy.

## Reproduction

Before the fix, decoding `{First: "first", Second: "second"}` through `NewDecoder(bytes.NewReader(...))` produced `{First: "secon", Second: "second"}`.

## Benchmarks

Apple M2, Go 1.25, 10 runs for the targeted benchmark. The pre-fix result is fast because it aliases mutable scratch memory and is incorrect.

| benchmark | master | fix | delta |
|---|---:|---:|---:|
| two short `nocopy.String` values via stream | 39.42 ns/op, 0 B, 0 allocs | 53.32 ns/op, 16 B, 2 allocs | +35.3%, +2 required allocations |
| repository `binary/stream-dec` | 132.6 ns/op, 1 alloc | 138.2 ns/op, 2 allocs | +4.2%, +1 allocation |
| slice-backed `nocopy/str-dec` | 32.0 ns/op, 0 allocs | 31.9 ns/op, 0 allocs | unchanged |

Full repository benchmark suite: `cd bench && go run .` (100 samples, 10 ms/sample).

## Checks

- `go test ./...`
- `go vet ./...`
- `git diff --check`