### PR TITLE
Add nocopy.JSON

### DIFF
--- a/nocopy/types.go
+++ b/nocopy/types.go
@@ -4,6 +4,7 @@
 package nocopy
 
 import (
+	"encoding/json"
 	"reflect"
 	"unsafe"
 
@@ -31,6 +32,27 @@ type Bytes []byte
 
 // GetBinaryCodec retrieves a custom binary codec.
 func (s *Bytes) GetBinaryCodec() binary.Codec {
+	return new(byteSliceCodec)
+}
+
+// ------------------------------------------------------------------------------
+
+// JSON represents raw JSON. JSON decoding copies its input, while binary
+// decoding reuses the underlying byte array.
+type JSON json.RawMessage
+
+// MarshalJSON returns j as the JSON encoding of j.
+func (j JSON) MarshalJSON() ([]byte, error) {
+	return json.RawMessage(j).MarshalJSON()
+}
+
+// UnmarshalJSON sets *j to a copy of data.
+func (j *JSON) UnmarshalJSON(data []byte) error {
+	return (*json.RawMessage)(j).UnmarshalJSON(data)
+}
+
+// GetBinaryCodec retrieves a custom binary codec.
+func (j *JSON) GetBinaryCodec() binary.Codec {
 	return new(byteSliceCodec)
 }
 

--- a/nocopy/types_test.go
+++ b/nocopy/types_test.go
@@ -5,11 +5,33 @@ package nocopy
 
 import (
 	"bytes"
+	"encoding/json"
 	"testing"
 
 	"github.com/kelindar/binary"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestJSON(t *testing.T) {
+	input := []byte(`{"answer":42}`)
+	var value JSON
+	assert.NoError(t, json.Unmarshal(input, &value))
+	input[2] = 'x'
+	assert.JSONEq(t, `{"answer":42}`, string(value))
+
+	output, err := json.Marshal(struct {
+		Value JSON `json:"value"`
+	}{Value: value})
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{"value":{"answer":42}}`, string(output))
+
+	encoded, err := binary.Marshal(value)
+	assert.NoError(t, err)
+	var decoded JSON
+	assert.NoError(t, binary.Unmarshal(encoded, &decoded))
+	encoded[len(encoded)-1] = '!'
+	assert.Equal(t, byte('!'), decoded[len(decoded)-1])
+}
 
 func TestStreamDecodeRetainsStrings(t *testing.T) {
 	type pair struct {
@@ -97,6 +119,10 @@ func TestTypes(t *testing.T) {
 			value: Bytes([]byte("ABCD")),
 			out:   new(Bytes),
 		},
+		"json": {
+			value: JSON(`{"answer":42}`),
+			out:   new(JSON),
+		},
 		"bools": {
 			value: Bools{true, false, true, true, false, false},
 			out:   new(Bools),
@@ -163,6 +189,8 @@ func deref(v any) any {
 	case *String:
 		return *x
 	case *Bytes:
+		return *x
+	case *JSON:
 		return *x
 	case *Bools:
 		return *x


### PR DESCRIPTION
## Summary

Add `nocopy.JSON`, a raw JSON value that works in the same struct with both `encoding/json` and `kelindar/binary`.

- JSON unmarshal copies input using `json.RawMessage` semantics
- JSON marshal emits raw JSON rather than base64
- binary decode reuses the underlying input slice through the existing `byteSliceCodec`

## Tests

Coverage verifies JSON input ownership, raw JSON output, binary aliasing, and the normal nocopy binary round trip.

## Checks

- `go test ./...`
- `go vet ./...`
- `git diff --check`