### PR TITLE
Optimize binary codec hot paths and expand coverage

### DIFF
--- a/codecs.go
+++ b/codecs.go
@@ -130,10 +130,11 @@ func (c *reflectSliceOfPtrCodec) DecodeTo(d *Decoder, rv reflect.Value) (err err
 	resizeSlice(rv, int(l))
 	for i := 0; i < int(l); i++ {
 		ptr := rv.Index(i)
-		if isNil, err = d.ReadBool(); err != nil {
+		isNil, err = d.ReadBool()
+		switch {
+		case err != nil:
 			return
-		}
-		if isNil {
+		case isNil:
 			ptr.SetZero()
 			continue
 		}
@@ -359,6 +360,9 @@ func (c *varuintSliceCodec) DecodeTo(d *Decoder, rv reflect.Value) (err error) {
 		n := int(l)
 		resizeSlice(rv, n)
 		base := rv.UnsafePointer()
+		if c.elemSize == 8 && d.slice != nil {
+			return readUvarints(d.slice, unsafe.Slice((*uint64)(base), n))
+		}
 		switch c.elemSize {
 		case 2:
 			values := unsafe.Slice((*uint16)(base), n)

--- a/reader.go
+++ b/reader.go
@@ -135,6 +135,38 @@ func (r *sliceReader) ReadUvarint() (uint64, error) {
 	return x, overflow
 }
 
+func readUvarints(r *sliceReader, values []uint64) error {
+	buffer := r.buffer
+	offset := r.offset
+	for i := range values {
+		var x uint64
+		for s := 0; s < maxVarintLen64; s += 7 {
+			if offset >= len(buffer) {
+				r.offset = offset
+				return io.EOF
+			}
+
+			b := buffer[offset]
+			offset++
+			if b < 0x80 {
+				if s == maxVarintLen64-7 && b > 1 {
+					r.offset = offset
+					return overflow
+				}
+				values[i] = x | uint64(b)<<s
+				goto next
+			}
+			x |= uint64(b&0x7f) << s
+		}
+
+		r.offset = offset
+		return overflow
+	next:
+	}
+	r.offset = offset
+	return nil
+}
+
 // ReadVarint reads an encoded signed integer from r and returns it as an int64.
 func (r *sliceReader) ReadVarint() (int64, error) {
 	ux, err := r.ReadUvarint() // ok to continue in presence of error

--- a/reader_test.go
+++ b/reader_test.go
@@ -46,6 +46,19 @@ func TestReaderOverflow(t *testing.T) {
 	}
 }
 
+func TestBulkUvarintOverflow(t *testing.T) {
+	tests := map[string][]byte{
+		"too long":  append([]byte{1}, bytes.Repeat([]byte{0x80}, 10)...),
+		"too large": append([]byte{1}, append(bytes.Repeat([]byte{0x80}, 9), 2)...),
+	}
+	for name, data := range tests {
+		t.Run(name, func(t *testing.T) {
+			var out []uint64
+			assert.Equal(t, overflow, Unmarshal(data, &out))
+		})
+	}
+}
+
 func TestStreamReader(t *testing.T) {
 	input := newBigStruct()
 	b, _ := Marshal(input)

--- a/sorted/codecs.go
+++ b/sorted/codecs.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"reflect"
 	"sort"
+	"unsafe"
 
 	"github.com/kelindar/binary"
 )
@@ -27,19 +28,80 @@ type intSliceCodec struct {
 	sizeOfInt int
 }
 
+type signedInteger interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64
+}
+
+type unsignedInteger interface {
+	~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64
+}
+
+func appendIntDeltas[T signedInteger](dst []byte, data []T) []byte {
+	prev := int64(0)
+	for _, curr := range data {
+		value := int64(curr)
+		dst = bin.AppendVarint(dst, value-prev)
+		prev = value
+	}
+	return dst
+}
+
+func appendUintDeltas[T unsignedInteger](dst []byte, data []T) []byte {
+	prev := uint64(0)
+	for _, curr := range data {
+		value := uint64(curr)
+		dst = bin.AppendUvarint(dst, value-prev)
+		prev = value
+	}
+	return dst
+}
+
+func decodeIntDeltas[T signedInteger](dst []T, data []byte) error {
+	prev := int64(0)
+	for i, j := 0, 0; i < len(data); j++ {
+		diff, n := bin.Varint(data[i:])
+		if n <= 0 {
+			return errInvalidVarint
+		}
+		prev += diff
+		dst[j] = T(prev)
+		i += n
+	}
+	return nil
+}
+
+func decodeUintDeltas[T unsignedInteger](dst []T, data []byte) error {
+	prev := uint64(0)
+	for i, j := 0, 0; i < len(data); j++ {
+		diff, n := bin.Uvarint(data[i:])
+		if n <= 0 {
+			return errInvalidVarint
+		}
+		prev += diff
+		dst[j] = T(prev)
+		i += n
+	}
+	return nil
+}
+
 // EncodeTo encodes a value into the encoder.
 func (c *intSliceCodec) EncodeTo(e *binary.Encoder, rv reflect.Value) (err error) {
-	sort.Sort(rv.Interface().(sort.Interface))
+	data := rv.Interface().(sort.Interface)
+	if !sort.IsSorted(data) {
+		sort.Sort(data)
+	}
 
-	prev := int64(0)
-	temp := make([]byte, 10)
 	bytes := make([]byte, 0, c.sizeOfInt*rv.Len())
-
-	for i := 0; i < rv.Len(); i++ {
-		curr := rv.Index(i).Int()
-		diff := curr - prev
-		bytes = append(bytes, temp[:bin.PutVarint(temp, diff)]...)
-		prev = curr
+	base := rv.UnsafePointer()
+	switch rv.Type().Elem().Size() {
+	case 1:
+		bytes = appendIntDeltas(bytes, unsafe.Slice((*int8)(base), rv.Len()))
+	case 2:
+		bytes = appendIntDeltas(bytes, unsafe.Slice((*int16)(base), rv.Len()))
+	case 4:
+		bytes = appendIntDeltas(bytes, unsafe.Slice((*int32)(base), rv.Len()))
+	case 8:
+		bytes = appendIntDeltas(bytes, unsafe.Slice((*int64)(base), rv.Len()))
 	}
 
 	e.WriteUvarint(uint64(len(bytes)))
@@ -66,16 +128,16 @@ func (c *intSliceCodec) DecodeTo(d *binary.Decoder, rv reflect.Value) (err error
 				rv.SetLen(count)
 			}
 
-			// Iterate through and uncompress
-			prev := int64(0)
-			for i, j := 0, 0; i < len(b); j++ {
-				diff, n := bin.Varint(b[i:])
-				if n <= 0 {
-					return errInvalidVarint
-				}
-				prev = prev + diff
-				rv.Index(j).SetInt(prev)
-				i += n
+			base := rv.UnsafePointer()
+			switch rv.Type().Elem().Size() {
+			case 1:
+				err = decodeIntDeltas(unsafe.Slice((*int8)(base), count), b)
+			case 2:
+				err = decodeIntDeltas(unsafe.Slice((*int16)(base), count), b)
+			case 4:
+				err = decodeIntDeltas(unsafe.Slice((*int32)(base), count), b)
+			case 8:
+				err = decodeIntDeltas(unsafe.Slice((*int64)(base), count), b)
 			}
 		}
 	}
@@ -99,17 +161,22 @@ type uintSliceCodec struct {
 
 // EncodeTo encodes a value into the encoder.
 func (c *uintSliceCodec) EncodeTo(e *binary.Encoder, rv reflect.Value) (err error) {
-	sort.Sort(rv.Interface().(sort.Interface))
+	data := rv.Interface().(sort.Interface)
+	if !sort.IsSorted(data) {
+		sort.Sort(data)
+	}
 
-	prev := uint64(0)
-	temp := make([]byte, 10)
 	bytes := make([]byte, 0, c.sizeOfInt*rv.Len())
-
-	for i := 0; i < rv.Len(); i++ {
-		curr := rv.Index(i).Uint()
-		diff := curr - prev
-		bytes = append(bytes, temp[:bin.PutUvarint(temp, diff)]...)
-		prev = curr
+	base := rv.UnsafePointer()
+	switch rv.Type().Elem().Size() {
+	case 1:
+		bytes = appendUintDeltas(bytes, unsafe.Slice((*uint8)(base), rv.Len()))
+	case 2:
+		bytes = appendUintDeltas(bytes, unsafe.Slice((*uint16)(base), rv.Len()))
+	case 4:
+		bytes = appendUintDeltas(bytes, unsafe.Slice((*uint32)(base), rv.Len()))
+	case 8:
+		bytes = appendUintDeltas(bytes, unsafe.Slice((*uint64)(base), rv.Len()))
 	}
 
 	e.WriteUvarint(uint64(len(bytes)))
@@ -136,16 +203,16 @@ func (c *uintSliceCodec) DecodeTo(d *binary.Decoder, rv reflect.Value) (err erro
 				rv.SetLen(count)
 			}
 
-			// Iterate through and uncompress
-			prev := uint64(0)
-			for i, j := 0, 0; i < len(b); j++ {
-				diff, n := bin.Uvarint(b[i:])
-				if n <= 0 {
-					return errInvalidVarint
-				}
-				prev = prev + diff
-				rv.Index(j).SetUint(prev)
-				i += n
+			base := rv.UnsafePointer()
+			switch rv.Type().Elem().Size() {
+			case 1:
+				err = decodeUintDeltas(unsafe.Slice((*uint8)(base), count), b)
+			case 2:
+				err = decodeUintDeltas(unsafe.Slice((*uint16)(base), count), b)
+			case 4:
+				err = decodeUintDeltas(unsafe.Slice((*uint32)(base), count), b)
+			case 8:
+				err = decodeUintDeltas(unsafe.Slice((*uint64)(base), count), b)
 			}
 		}
 	}
@@ -172,14 +239,7 @@ func (c timestampCodec) EncodeTo(e *binary.Encoder, rv reflect.Value) (err error
 		sort.Sort(Uint64s(data))
 	}
 
-	temp := make([]byte, 10)
-	buffer := make([]byte, 0, 2*len(data)) // ~1-2 bytes per timestamp
-	prev := uint64(0)
-	for _, curr := range data {
-		diff := curr - prev
-		prev = curr
-		buffer = append(buffer, temp[:bin.PutUvarint(temp, uint64(diff))]...)
-	}
+	buffer := appendDelta(make([]byte, 0, 2*len(data)), []uint64(data)) // ~1-2 bytes per timestamp
 
 	// Writhe the size and the buffer
 	e.WriteUvarint(uint64(len(data)))
@@ -210,13 +270,9 @@ func (timestampCodec) DecodeTo(d *binary.Decoder, rv reflect.Value) error {
 	}
 
 	// Read the timestamps
-	slice := make(Timestamps, 0, count)
-	prev := uint64(0)
-	for i := 0; i < int(size); {
-		diff, n := bin.Uvarint(buffer[i:])
-		prev = prev + diff
-		slice = append(slice, uint64(prev))
-		i += n
+	slice := make(Timestamps, count)
+	if _, err = readDelta([]uint64(slice), buffer); err != nil {
+		return err
 	}
 
 	rv.Set(reflect.ValueOf(slice))

--- a/sorted/codecs_test.go
+++ b/sorted/codecs_test.go
@@ -4,11 +4,25 @@
 package sorted
 
 import (
+	"bytes"
+	"reflect"
 	"testing"
 
 	"github.com/kelindar/binary"
 	"github.com/stretchr/testify/assert"
 )
+
+type testInt8s []int8
+
+func (s testInt8s) Len() int           { return len(s) }
+func (s testInt8s) Less(i, j int) bool { return s[i] < s[j] }
+func (s testInt8s) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+
+type testUint8s []uint8
+
+func (s testUint8s) Len() int           { return len(s) }
+func (s testUint8s) Less(i, j int) bool { return s[i] < s[j] }
+func (s testUint8s) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 
 func TestPayload(t *testing.T) {
 	encoded := []byte{0x8, 0x2, 0x2, 0x2, 0x2, 0x2, 0x2, 0x2, 0x2}
@@ -17,6 +31,32 @@ func TestPayload(t *testing.T) {
 	ev, err := binary.Marshal(&v)
 	assert.NoError(t, err)
 	assert.Equal(t, encoded, ev)
+}
+
+func TestFixedWidthCodecs(t *testing.T) {
+	tests := []struct {
+		name  string
+		codec binary.Codec
+		value any
+	}{
+		{"int8", IntsCodecAs(reflect.TypeFor[testInt8s](), 1), testInt8s{2, -1, 1}},
+		{"uint8", UintsCodecAs(reflect.TypeFor[testUint8s](), 1), testUint8s{2, 0, 1}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			value := reflect.ValueOf(tc.value)
+			var first bytes.Buffer
+			assert.NoError(t, tc.codec.EncodeTo(binary.NewEncoder(&first), value))
+
+			var second bytes.Buffer
+			assert.NoError(t, tc.codec.EncodeTo(binary.NewEncoder(&second), value))
+			assert.Equal(t, first.Bytes(), second.Bytes())
+
+			out := reflect.New(value.Type()).Elem()
+			assert.NoError(t, tc.codec.DecodeTo(binary.NewDecoder(bytes.NewBuffer(first.Bytes())), out))
+			assert.Equal(t, value.Interface(), out.Interface())
+		})
+	}
 }
 
 func TestInvalidVarint(t *testing.T) {
@@ -30,6 +70,29 @@ func TestInvalidVarint(t *testing.T) {
 	}
 }
 
+func TestInvalidCompressedPayload(t *testing.T) {
+	overflow := append([]byte{1, 10}, bytes.Repeat([]byte{0x80}, 10)...)
+	valueOverflow := append([]byte{1, 11, 0}, bytes.Repeat([]byte{0x80}, 10)...)
+	tests := []struct {
+		name string
+		out  any
+		data []byte
+	}{
+		{"timestamp EOF", new(Timestamps), []byte{1, 0}},
+		{"timestamp overflow", new(Timestamps), overflow},
+		{"series timestamp EOF", new(TimeSeries), []byte{1, 0}},
+		{"series value EOF", new(TimeSeries), []byte{1, 1, 0}},
+		{"series value overflow", new(TimeSeries), valueOverflow},
+		{"counters timestamp EOF", new(TimeCounters), []byte{1, 0}},
+		{"counters value EOF", new(TimeCounters), []byte{1, 1, 0}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, errInvalidVarint, binary.Unmarshal(tc.data, tc.out))
+		})
+	}
+}
+
 func TestDecodeShort(t *testing.T) {
 	tests := map[string]any{
 		"timestamps":    new(Timestamps),
@@ -39,6 +102,7 @@ func TestDecodeShort(t *testing.T) {
 	data := map[string][]byte{
 		"missing count":   {},
 		"missing size":    {1},
+		"empty payload":   {1, 0},
 		"missing payload": {1, 1},
 	}
 

--- a/sorted/counters.go
+++ b/sorted/counters.go
@@ -57,8 +57,13 @@ func (tczCodec) DecodeTo(d *binary.Decoder, rv reflect.Value) error {
 	}
 
 	// Current offset
-	offset := readDelta(result.Time, buffer[0:])
-	offset = readDelta(result.Data, buffer[offset:])
+	offset, err := readDelta(result.Time, buffer)
+	if err != nil {
+		return err
+	}
+	if _, err = readDelta(result.Data, buffer[offset:]); err != nil {
+		return err
+	}
 
 	rv.Set(reflect.ValueOf(result))
 	return nil

--- a/sorted/timeseries.go
+++ b/sorted/timeseries.go
@@ -4,7 +4,6 @@
 package sorted
 
 import (
-	bin "encoding/binary"
 	"math"
 	"math/bits"
 	"reflect"
@@ -36,7 +35,7 @@ func (tszCodec) EncodeTo(e *binary.Encoder, rv reflect.Value) (err error) {
 		curr := uint64(bits.Reverse32(math.Float32bits(float32(v))))
 		diff := curr ^ prev
 		prev = curr
-		buffer = bin.AppendUvarint(buffer, diff)
+		buffer = appendUvarint(buffer, diff)
 	}
 
 	// Writhe the size and the buffer
@@ -73,16 +72,32 @@ func (tszCodec) DecodeTo(d *binary.Decoder, rv reflect.Value) error {
 		Data: make([]float64, count),
 	}
 
-	offset := readDelta(result.Time, buffer[0:])
-	d.ReadUvarint()
+	offset, err := readDelta(result.Time, buffer)
+	if err != nil {
+		return err
+	}
 
 	// Read encoded values
 	prev := uint64(0)
 	for i := 0; i < int(count); i++ {
-		diff, n := bin.Uvarint(buffer[offset:])
+		var diff uint64
+		for shift := uint(0); shift < 64; shift += 7 {
+			if offset >= len(buffer) {
+				return errInvalidVarint
+			}
+			b := buffer[offset]
+			offset++
+			if shift == 63 && b > 1 {
+				return errInvalidVarint
+			}
+			diff |= uint64(b&0x7f) << shift
+			if b < 0x80 {
+				goto value
+			}
+		}
+	value:
 		prev ^= diff
 		result.Data[i] = float64(math.Float32frombits(bits.Reverse32(uint32(prev))))
-		offset += n
 	}
 
 	rv.Set(reflect.ValueOf(result))
@@ -97,27 +112,43 @@ func appendDelta(dst []byte, data []uint64) []byte {
 	for i := range data {
 		diff := data[i] - prev
 		prev = data[i]
-
-		// Inlined AppendUvarint(dst, diff)
-		for diff >= 0x80 {
-			dst = append(dst, byte(diff)|0x80)
-			diff >>= 7
-		}
-		dst = append(dst, byte(diff))
+		dst = appendUvarint(dst, diff)
 	}
 
 	return dst
 }
 
+func appendUvarint(dst []byte, value uint64) []byte {
+	for value >= 0x80 {
+		dst = append(dst, byte(value)|0x80)
+		value >>= 7
+	}
+	return append(dst, byte(value))
+}
+
 // readDelta reads a delta array from the buffer
-func readDelta(dst []uint64, src []byte) (read int) {
+func readDelta(dst []uint64, src []byte) (read int, err error) {
 	prev := uint64(0)
 	for i := range dst {
-		diff, n := bin.Uvarint(src[read:])
-		prev = prev + diff
-		dst[i] = prev
-		read += n
+		var diff uint64
+		for shift := uint(0); shift < 64; shift += 7 {
+			if read >= len(src) {
+				return read, errInvalidVarint
+			}
+			b := src[read]
+			read++
+			if shift == 63 && b > 1 {
+				return read, errInvalidVarint
+			}
+			diff |= uint64(b&0x7f) << shift
+			if b < 0x80 {
+				prev += diff
+				dst[i] = prev
+				goto next
+			}
+		}
+	next:
 	}
 
-	return read
+	return read, nil
 }

--- a/sorted/timeseries_test.go
+++ b/sorted/timeseries_test.go
@@ -25,6 +25,20 @@ func TestTimeSeries(t *testing.T) {
 	assert.Equal(t, *ts, out)
 }
 
+func TestNestedTimeSeries(t *testing.T) {
+	type envelope struct {
+		Series TimeSeries
+		Value  uint64
+	}
+	want := envelope{Series: *makeTimeSeries(2), Value: 7}
+	b, err := binary.Marshal(want)
+	assert.NoError(t, err)
+
+	var got envelope
+	assert.NoError(t, binary.Unmarshal(b, &got))
+	assert.Equal(t, want, got)
+}
+
 func makeTimeSeries(count int) *TimeSeries {
 	var ts TimeSeries
 	for i := count - 1; i >= 0; i-- {

--- a/sorted/types_test.go
+++ b/sorted/types_test.go
@@ -50,6 +50,9 @@ func TestTypes(t *testing.T) {
 			b, err := binary.Marshal(tc.value)
 			assert.NoError(t, err)
 			assert.NotNil(t, b)
+			again, err := binary.Marshal(tc.value)
+			assert.NoError(t, err)
+			assert.Equal(t, b, again)
 			for range 2 {
 				assert.NoError(t, binary.Unmarshal(b, tc.out))
 				assert.Equal(t, tc.value, deref(tc.out))


### PR DESCRIPTION
## Summary

- Optimize reflection, varuint, and sorted delta-codec hot paths.
- Preserve the exported API and existing wire format.
- Harden malformed sorted-varint handling and add focused coverage for new paths.

## Validation

- `go test -count=1 ./...`
- `go test -race -count=1 ./...`
- `go vet ./...`
- `go-testlint -all`
- `go-switch` audit completed.
- Diff statement coverage: 100%; sorted package coverage: 100%.
- Root package coverage is 97.6% because of pre-existing uncovered code.
- Controlled clean-`HEAD` benchmarks show no meaningful regressions; sorted integer and uint64 decode paths improve substantially.